### PR TITLE
Add a protocol for agents

### DIFF
--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -1,0 +1,51 @@
+"""A base protocol for agents"""
+
+from typing import Any, Callable, List, Protocol
+
+import tiktoken
+
+from ..logging import logger
+from ..chat import ChatCompletionMessageParam, ChatCompletion
+
+
+class BaseAgent(Protocol):
+    """The base protocol for agents"""
+
+    def create_completion(
+        self, *, messages: List[ChatCompletionMessageParam], **kwargs: Any
+    ) -> ChatCompletion:
+        """Create a completion"""
+
+    def count_tokens(self, s: str) -> int:
+        """Count the tokens in the string, according to the model's agent(s)"""
+
+
+PreCompletionFn = Callable[
+    [List[ChatCompletionMessageParam]], List[ChatCompletionMessageParam]
+]
+
+CompletionCallback = Callable[[List[ChatCompletionMessageParam], ChatCompletion], None]
+
+
+class TikTokenLogger:
+    """A completion callback class for logging the number of tokens in the messages"""
+
+    _tokenizer: tiktoken.Encoding
+
+    def __init__(self, model_name: str):
+        self._tokenizer = tiktoken.encoding_for_model(model_name)
+
+    def tiktoken_logger(
+        self, messages: List[ChatCompletionMessageParam]
+    ) -> List[ChatCompletionMessageParam]:
+        """Log the number of tokens in the messages"""
+
+        # TODO(dbmikus) I'm not sure if this is how OpenAI combines multiple
+        # message objects into a single string before tokenizing.
+        joined = "\n".join([f"{m['role']}: {m['content']}" for m in messages])
+        tokenized = self._tokenizer.encode(joined)
+
+        # TODO(dbmikus) replace with a logger
+        # logger.info(f"Total input tokens: {len(tokenized)}")
+        logger.info("Total input tokens: %s", len(tokenized))
+        return messages

--- a/src/fixpoint/chat/__init__.py
+++ b/src/fixpoint/chat/__init__.py
@@ -1,0 +1,7 @@
+"""Types, objects, and functions for dealing with LLM chat"""
+
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+__all__ = ["ChatCompletionMessageParam", "ChatCompletion", "ChatCompletionMessage"]

--- a/src/fixpoint/logging.py
+++ b/src/fixpoint/logging.py
@@ -1,0 +1,7 @@
+"""Logging for the Fixpoint SDK."""
+
+import logging
+
+LOGGER_NAME = "fixpoint"
+
+logger = logging.getLogger(LOGGER_NAME)


### PR DESCRIPTION
Add a `Protocol` subclass to define the agent protocol[1] (aka the interface).

This also adds two other modules.

`chat`: the place for chat-related type and value definitions. Right now, it is just re-exporting the OpenAI chat types. By making our package use the type definitions from this module, we can later easily swap out the OpenAI types to more flexible types that work with different providers.

`logging`: holds a logger that we can use throughout the package, and exposes that logger to the package users so they can modify the logger (log-level, etcetera).

[1]: https://typing.readthedocs.io/en/latest/spec/protocol.html