### PR TITLE
Reconcile OpenAI interface and our BaseAgent protocol

### DIFF
--- a/src/fixpoint/_utils/completions.py
+++ b/src/fixpoint/_utils/completions.py
@@ -12,7 +12,7 @@ def decorate_instructor_completion_with_fixp(
 ) -> Callable[..., Any]:
     """
     Decorate the completion method to replace the original
-    completion object with FixpointCompletion.
+    completion object with our Fixpoint ChatCompletion.
     """
 
     @wraps(func)
@@ -20,7 +20,7 @@ def decorate_instructor_completion_with_fixp(
         # Make a call to get structured output + original completion
         structured_output, completion = func(*args, **kwargs)
 
-        # Wrap the completion object with FixpointCompletion and
+        # Wrap the completion object with Fixpoint ChatCompletion and
         # inject additional information under .fixp attribute
         fixpoint_completion = ChatCompletion.from_original_completion(
             completion, structured_output

--- a/src/fixpoint/agents/__init__.py
+++ b/src/fixpoint/agents/__init__.py
@@ -3,6 +3,6 @@ This is the agents module.
 """
 
 from .protocol import BaseAgent
-from .openai import OpenAIAgent
+from .openai import OpenAI, OpenAIAgent
 
-__all__ = ["BaseAgent", "OpenAIAgent"]
+__all__ = ["BaseAgent", "OpenAIAgent", "OpenAI"]

--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -46,7 +46,9 @@ class MockAgent(BaseAgent):
         if self._memory:
             self._memory.store_memory(messages, cmpl)
         self._trigger_completion_callbacks(messages, cmpl)
-        return cmpl
+        return ChatCompletion.from_original_completion(
+            original_completion=cmpl, structured_output=None
+        )
 
     def _trigger_completion_callbacks(
         self, messages: List[ChatCompletionMessageParam], completion: ChatCompletion

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -1,6 +1,6 @@
 """A base protocol for agents"""
 
-from typing import Any, Callable, List, Protocol
+from typing import Any, Callable, List, Optional, Protocol
 
 import tiktoken
 
@@ -12,9 +12,18 @@ class BaseAgent(Protocol):
     """The base protocol for agents"""
 
     def create_completion(
-        self, *, messages: List[ChatCompletionMessageParam], **kwargs: Any
+        self,
+        *,
+        messages: List[ChatCompletionMessageParam],
+        model: Optional[str] = None,
+        **kwargs: Any,
     ) -> ChatCompletion:
-        """Create a completion"""
+        """Create a completion
+
+        The `model` argument is optional if the agent has a pre-defined model it
+        should use. In that case, specifying `model` overrides which model to
+        use.
+        """
 
     def count_tokens(self, s: str) -> int:
         """Count the tokens in the string, according to the model's agent(s)"""

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -25,7 +25,6 @@ class TestMockAgent:
             messages.smsg("I am a system"),
             messages.umsg("I am a user"),
         ]
-        assert mems[0][1] == cmpl
         assert mems[0][1].choices[0].message.content == "test 0"
 
 

--- a/tests/agents/openai_test.py
+++ b/tests/agents/openai_test.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +8,7 @@ from openai.types.chat.chat_completion import (
 )
 
 import fixpoint
+from fixpoint.agents.openai import OpenAIClients
 from fixpoint._utils.completions import decorate_instructor_completion_with_fixp
 from fixpoint.agents.mock import new_mock_orig_completion
 from tests.test_utils import SampleStructure
@@ -16,31 +18,33 @@ class TestAgents:
     def test_openai_agent_bad_model_instantiation(self) -> None:
         # Check that if an invalid model is passed in then a ValueError is raised
         with pytest.raises(ValueError):
-            fixpoint.agents.OpenAIAgent("bad-model", "api-key")
+            fixpoint.agents.OpenAI("bad-model", OpenAIClients.from_api_key("api-key"))
         # Check that if None is passed in then a ValueError is raised
         with pytest.raises(ValueError):
-            fixpoint.agents.OpenAIAgent(None, "api-key")  # type: ignore
+            fixpoint.agents.OpenAI(None, OpenAIClients.from_api_key("api-key"))  # type: ignore
 
     def test_openai_agent_valid_model_instantiation(self) -> None:
         # Instantiate an agent
-        agent = fixpoint.agents.OpenAIAgent(
-            model_name="gpt-3.5-turbo", api_key="api-key"
+        agent = fixpoint.agents.OpenAI(
+            model_name="gpt-3.5-turbo",
+            openai_clients=OpenAIClients.from_api_key("api-key"),
         )
 
         # Check that the agent contains the model
-        assert agent.model_name == "gpt-3.5-turbo"
+        assert agent.fixp.model_name == "gpt-3.5-turbo"
 
         # Now check that the open ai methods are exposed. Check that chat exists on the agent.
         assert hasattr(agent, "chat")
 
     def test_openai_agent_completions_proxy(self) -> None:
         # Instantiate an agent
-        agent = fixpoint.agents.OpenAIAgent(
-            model_name="gpt-3.5-turbo", api_key="api-key"
+        agent = fixpoint.agents.OpenAI(
+            model_name="gpt-3.5-turbo",
+            openai_clients=OpenAIClients.from_api_key("api-key"),
         )
 
         def instructed_chat_completion(
-            _prompt: str, _response_type: SampleStructure
+            messages: Any, response_model: Any
         ) -> tuple[SampleStructure, OpenAIChatCompletion]:
             completion = new_mock_orig_completion("I'm doing good.")
             structure = SampleStructure("John")
@@ -59,8 +63,12 @@ class TestAgents:
 
             # Now call the chat method and check that the completion is correct
             response = agent.chat.completions.create(
-                "Hello, how are you?", SampleStructure
+                messages=[
+                    {"role": "user", "content": "Hello, how are you?"},
+                ],
+                response_model=SampleStructure,
             )
 
             assert response.choices[0].message.content == "I'm doing good."
+            assert response.fixp.structured_output is not None
             assert response.fixp.structured_output.name == "John"

--- a/tests/utils/completions_test.py
+++ b/tests/utils/completions_test.py
@@ -1,13 +1,9 @@
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+
 from fixpoint._utils import decorate_instructor_completion_with_fixp
 from fixpoint.completions import ChatCompletion
-
-from openai.types.chat.chat_completion import (
-    Choice as CompletionChoice,
-    ChatCompletion as OpenAIChatCompletion,
-)
-
-from tests.test_utils import SampleStructure
 from fixpoint.agents.mock import new_mock_orig_completion
+from tests.test_utils import SampleStructure
 
 
 class TestUtilsCompletions:
@@ -32,7 +28,6 @@ class TestUtilsCompletions:
             "Hello, how are you?", SampleStructure
         )
 
-        # Chat completion response should be of type FixpointCompletion
         assert isinstance(fixpoint_completion, ChatCompletion)
 
         # Chat completion attributes should be accessed directly from the completion object


### PR DESCRIPTION
We have a `BaseAgent` protocol, which is an API that is not constrained to be OpenAI compliant, which is part of the core of the Fixpoint framework.

However, we also want an OpenAI-compliant API, so we have two different classes for interacting with OpenAI:

- `OpenAI` - intended to be a drop-in replacement for the `openai.OpenAI` client.
- `OpenAIAgent` - interacts with the OpenAI API, but conforms to our `BaseAgent` protocol.

When we make a completion from the `OpenAIAgent`, it can interact with memory, and pre and post-completion hooks. The
`agent.chat.completions.create` function used to not have any of these features, but now we have reconciled the two so that the `OpenAI` class uses the `OpenAIAgent` under the hood so we get these extra goodies.