### PR TITLE
Hook up workflows into agent

### DIFF
--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -15,6 +15,7 @@ from ..completions import (
 )
 from .protocol import BaseAgent, CompletionCallback, PreCompletionFn
 from ..memory import SupportsMemory
+from ..workflow import SupportsWorkflow
 
 
 class MockAgent(BaseAgent):
@@ -38,13 +39,21 @@ class MockAgent(BaseAgent):
         self._memory = memory
 
     def create_completion(
-        self, *, messages: List[ChatCompletionMessageParam], **kwargs: Any
+        self,
+        *,
+        messages: List[ChatCompletionMessageParam],
+        model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
+        response_model: Optional[Any] = None,
+        **kwargs: Any,
     ) -> ChatCompletion:
         for fn in self._pre_completion_fns:
             messages = fn(messages)
         cmpl = self._completion_fn()
         if self._memory:
-            self._memory.store_memory(messages, cmpl)
+            self._memory.store_memory(
+                messages=messages, completion=cmpl, workflow=workflow
+            )
         self._trigger_completion_callbacks(messages, cmpl)
         return ChatCompletion.from_original_completion(
             original_completion=cmpl, structured_output=None

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -13,6 +13,7 @@ import tiktoken
 from ..completions import ChatCompletion, ChatCompletionMessageParam
 from .protocol import BaseAgent, CompletionCallback, PreCompletionFn
 from ..memory import SupportsMemory
+from ..workflow import SupportsWorkflow
 
 
 @dataclass
@@ -73,6 +74,7 @@ class OpenAIAgent(BaseAgent):
         *,
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
         response_model: Optional[Any] = None,
         **kwargs: Any,
     ) -> ChatCompletion:
@@ -90,7 +92,7 @@ class OpenAIAgent(BaseAgent):
         )
 
         if self._memory is not None:
-            self._memory.store_memory(messages, fixp_completion)
+            self._memory.store_memory(messages, fixp_completion, workflow)
         self._trigger_completion_callbacks(messages, fixp_completion)
         return fixp_completion
 
@@ -232,9 +234,14 @@ class OpenAI:
             *,
             model: Optional[str] = None,
             response_model: Optional[Any] = None,
+            workflow: Optional[SupportsWorkflow] = None,
             **kwargs: Any,
         ) -> ChatCompletion:
             """Create a chat completion"""
             return self._agent.create_completion(
-                messages=messages, model=model, response_model=response_model, **kwargs
+                messages=messages,
+                model=model,
+                response_model=response_model,
+                workflow=workflow,
+                **kwargs,
             )

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -6,6 +6,7 @@ import tiktoken
 
 from ..logging import logger
 from ..completions import ChatCompletionMessageParam, ChatCompletion
+from ..workflow import SupportsWorkflow
 
 
 class BaseAgent(Protocol):
@@ -16,6 +17,8 @@ class BaseAgent(Protocol):
         *,
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
+        response_model: Optional[Any] = None,
         **kwargs: Any,
     ) -> ChatCompletion:
         """Create a completion

--- a/src/fixpoint/memory/__init__.py
+++ b/src/fixpoint/memory/__init__.py
@@ -1,12 +1,13 @@
 """LLM agent memory"""
 
 from ._memgpt import MemGPTSummarizeOpts, MemGPTSummaryAgent, memgpt_summarize
-from ._memory import Memory, SupportsMemory
+from ._memory import Memory, SupportsMemory, MemoryItem
 
 __all__ = [
     "MemGPTSummarizeOpts",
     "MemGPTSummaryAgent",
     "Memory",
     "SupportsMemory",
+    "MemoryItem",
     "memgpt_summarize",
 ]

--- a/src/fixpoint/memory/_memgpt.py
+++ b/src/fixpoint/memory/_memgpt.py
@@ -23,6 +23,7 @@ from typing import Any, List, Optional
 from ..logging import logger
 from ..agents.protocol import BaseAgent
 from ..completions import ChatCompletionMessageParam, ChatCompletion
+from ..workflow import SupportsWorkflow
 
 
 @dataclass
@@ -51,6 +52,9 @@ class MemGPTSummaryAgent:
         self,
         *,
         messages: List[ChatCompletionMessageParam],
+        model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
+        response_model: Optional[Any] = None,
         **kwargs: Any,
     ) -> ChatCompletion:
         """Create a chat completion, using historical (maybe summarized) messages in context"""
@@ -67,7 +71,11 @@ class MemGPTSummaryAgent:
             self._messages = [{"role": "system", "content": summary}]
 
         cmpl = self._opts.agent.create_completion(
-            messages=self._messages + messages, **kwargs
+            messages=self._messages + messages,
+            model=model,
+            workflow=workflow,
+            response_model=response_model,
+            **kwargs,
         )
         self._messages += messages + [
             {"role": "assistant", "content": cmpl.choices[0].message.content}

--- a/src/fixpoint/workflow/__init__.py
+++ b/src/fixpoint/workflow/__init__.py
@@ -1,0 +1,10 @@
+"""Agents work in a "workflow".
+
+A "workflow" is a series of steps that one or more agents takes to accomplish
+some goal.
+"""
+
+from ._workflow import Workflow
+from .protocol import SupportsWorkflow
+
+__all__ = ["Workflow", "SupportsWorkflow"]

--- a/src/fixpoint/workflow/_workflow.py
+++ b/src/fixpoint/workflow/_workflow.py
@@ -1,0 +1,12 @@
+"""Simple implementation of a workflow"""
+
+from dataclasses import dataclass
+
+from .protocol import SupportsWorkflow
+
+
+@dataclass
+class Workflow(SupportsWorkflow):
+    """A simple workflow implementation"""
+
+    id: str

--- a/src/fixpoint/workflow/protocol.py
+++ b/src/fixpoint/workflow/protocol.py
@@ -1,0 +1,9 @@
+"""Protocol for workflows"""
+
+from typing import Protocol
+
+
+class SupportsWorkflow(Protocol):
+    """A protocol for a Workflow"""
+
+    id: str

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -21,11 +21,11 @@ class TestMockAgent:
         assert cmpl.choices[0].message.content == "test 0"
         mems = mem.memory()
         assert len(mems) == 1
-        assert mems[0][0] == [
+        assert mems[0].messages == [
             messages.smsg("I am a system"),
             messages.umsg("I am a user"),
         ]
-        assert mems[0][1].choices[0].message.content == "test 0"
+        assert mems[0].completion.choices[0].message.content == "test 0"
 
 
 class MockCompletionGenerator:

--- a/tests/memory/test_memgpt.py
+++ b/tests/memory/test_memgpt.py
@@ -31,7 +31,7 @@ class TestMemGPTSummaryAgent:
         assert len(mem.memory()) == 1
         # We are under the token limit, so we did not summarize and product any
         # extra messages.
-        assert len(mem.memory()[0][0]) == 2
+        assert len(mem.memory()[0].messages) == 2
 
 
 def test_context_length_check() -> None:

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from fixpoint.completions import ChatCompletionMessageParam
-from fixpoint.memory import Memory
+from fixpoint.memory import Memory, MemoryItem
 from fixpoint.agents.mock import new_mock_completion
 
 
@@ -14,4 +14,4 @@ class TestWithMemory:
         ]
         cmpl = new_mock_completion()
         memstore.store_memory(msgs, cmpl)
-        assert memstore.memory() == [(msgs, cmpl)]
+        assert memstore.memory() == [MemoryItem(messages=msgs, completion=cmpl)]


### PR DESCRIPTION
Create a `fixpoint.workflow` module and then hook up the workflow objects into an agent's `create_completion` method, so that we can mark the completion as belonging to that workflow.

We modified the `fixpoint.memory` so that each memory item is now a `MemoryItem` class instead of a tuple of input messages and output completion. Then we could add the workflow entry to the `MemoryItem`.