### PR TITLE
Add support for caching to disk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -614,6 +614,17 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+description = "Disk Cache -- Disk and file backed persistent cache."
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
+    {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -1686,8 +1697,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2077,8 +2088,8 @@ astroid = ">=3.2.2,<=3.3.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
 mccabe = ">=0.6,<0.8"
@@ -2902,4 +2913,4 @@ analyze = ["pandas"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "df89adb70489bb75a6dd7ffa457c80dff9ca5d33dd0784373a5f2382497de3a0"
+content-hash = "7dc018c2b45e24e175d1c9195470f18344fb75ce86a2ae4afb713542cc426293"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ types-cachetools = "^5.3.0.7"
 cachetools = "^5.3.3"
 pandas = { version = "^2.2.2", optional = true }
 jinja2 = "^3.1.4"
+diskcache = "^5.6.3"
 
 [tool.poetry.group.dev.dependencies]
 freezegun = "^1.5.1"

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -217,6 +217,9 @@ class OpenAI:
         pre_completion_fns: Optional[List[PreCompletionFn]] = None,
         completion_callbacks: Optional[List[CompletionCallback]] = None,
         memory: Optional[SupportsMemory] = None,
+        cache: Optional[
+            SupportsCache[List[ChatCompletionMessageParam], ChatCompletion]
+        ] = None,
     ) -> None:
         self.fixp = OpenAIAgent(
             model_name=model_name,
@@ -224,6 +227,7 @@ class OpenAI:
             pre_completion_fns=pre_completion_fns,
             completion_callbacks=completion_callbacks,
             memory=memory,
+            cache=cache,
         )
 
         self._fixpchat = OpenAI._Chat(openai_clients.instructor.chat, self.fixp)

--- a/src/fixpoint/cache/_shared.py
+++ b/src/fixpoint/cache/_shared.py
@@ -1,0 +1,18 @@
+"""shared internal code for the caching module"""
+
+import json
+from typing import Any
+
+
+def hash_key(key: Any) -> int:
+    """Hash a key to an int"""
+    if isinstance(key, (dict, list, set)):
+        # Convert unhashable types to a JSON string
+        try:
+            key_str = json.dumps(key, sort_keys=True)
+        except TypeError as e:
+            # Handle types that are not serializable by json.dumps
+            raise ValueError(f"Key of type {type(key)} is not serializable: {e}") from e
+
+        return hash(key_str)
+    return hash(key)

--- a/src/fixpoint/cache/disktlru.py
+++ b/src/fixpoint/cache/disktlru.py
@@ -1,0 +1,68 @@
+"""A TLRU cache that stores items on disk"""
+
+import tempfile
+from typing import Union, cast
+
+import diskcache
+
+from ..logging import logger
+from .protocol import SupportsCache, K_contra, V
+from ._shared import hash_key
+
+# 50 MB
+_DEFAULT_SIZE_LIMIT_BYTES = 50 * 1024 * 1024
+
+
+class DiskTLRUCache(SupportsCache[K_contra, V]):
+    """A TLRU cache that stores items on disk"""
+
+    _ttl_s: float
+    _cache: diskcache.Cache
+    _size_limit_bytes: int
+
+    def __init__(
+        self,
+        cache_dir: str,
+        # TTL in seconds
+        ttl_s: float,
+        # 50 MB
+        size_limit_bytes: int = _DEFAULT_SIZE_LIMIT_BYTES,
+    ) -> None:
+        self._cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        self._ttl_s = ttl_s
+        self._size_limit_bytes = size_limit_bytes
+
+    @classmethod
+    def from_tmpdir(
+        cls, ttl_s: float, size_limit_bytes: int = _DEFAULT_SIZE_LIMIT_BYTES
+    ) -> "DiskTLRUCache[K_contra, V]":
+        """Create a new cache from inside a temporary directory"""
+        tmpdir = tempfile.mkdtemp()
+        logger.debug("Created temporary directory for disk cache: %s", tmpdir)
+        return cls(cache_dir=tmpdir, ttl_s=ttl_s, size_limit_bytes=size_limit_bytes)
+
+    def get(self, key: K_contra) -> Union[V, None]:
+        """Retrieve an item by key"""
+        return cast(Union[V, None], self._cache.get(hash_key(key)))
+
+    def set(self, key: K_contra, value: V) -> None:
+        """Set an item by key"""
+        self._cache.set(hash_key(key), value, expire=self._ttl_s)
+
+    def delete(self, key: K_contra) -> None:
+        """Delete an item by key"""
+        self._cache.delete(hash_key(key))
+
+    def clear(self) -> None:
+        """Clear all items from the cache"""
+        self._cache.clear()
+
+    @property
+    def maxsize(self) -> int:
+        """Property to get the maxsize of the cache"""
+        return self._size_limit_bytes
+
+    @property
+    def currentsize(self) -> int:
+        """Property to get the currentsize of the cache"""
+        return cast(int, self._cache.volume())

--- a/src/fixpoint/cache/tlru.py
+++ b/src/fixpoint/cache/tlru.py
@@ -3,12 +3,12 @@ TLRU Cache
 """
 
 import time
-import json
 from threading import RLock
 from typing import Union, Any
 from cachetools import TLRUCache as CachetoolsTLRUCache
 
-from fixpoint.cache.protocol import SupportsCache, K_contra, V, SupportsTTLCacheItem
+from .protocol import SupportsCache, K_contra, V, SupportsTTLCacheItem
+from ._shared import hash_key
 
 
 class TLRUCacheItem(SupportsTTLCacheItem):
@@ -63,18 +63,7 @@ class TLRUCache(SupportsCache[K_contra, V]):
         self._ttl = ttl
 
     def _hash_key(self, key: K_contra) -> int:
-        if isinstance(key, (dict, list, set)):
-            # Convert unhashable types to a JSON string
-            try:
-                key_str = json.dumps(key, sort_keys=True)
-            except TypeError as e:
-                # Handle types that are not serializable by json.dumps
-                raise ValueError(
-                    f"Key of type {type(key)} is not serializable: {e}"
-                ) from e
-
-            return hash(key_str)
-        return hash(key)
+        return hash_key(key)
 
     def get(self, key: K_contra) -> Union[Any, None]:
         with self.lock:


### PR DESCRIPTION
I added a cache that supports caching to disk, so that when I restart my Jupyter kernel I can keep the same inference cache. I used the [Diskcache](https://grantjenks.com/docs/diskcache/) package, which I have used in another project. It is fast, Python-only, and backed by SQLite.