### PR TITLE
Allow control over when agent caches

### DIFF
--- a/src/fixpoint/agents/__init__.py
+++ b/src/fixpoint/agents/__init__.py
@@ -4,5 +4,6 @@ This is the agents module.
 
 from .protocol import BaseAgent
 from .openai import OpenAI, OpenAIAgent
+from ._shared import CacheMode
 
-__all__ = ["BaseAgent", "OpenAIAgent", "OpenAI"]
+__all__ = ["BaseAgent", "OpenAIAgent", "OpenAI", "CacheMode"]

--- a/src/fixpoint/agents/_shared.py
+++ b/src/fixpoint/agents/_shared.py
@@ -1,0 +1,42 @@
+"""Internal shared code for the "agents" module."""
+
+from typing import Callable, List, Optional, Literal
+
+from ..cache import ChatCompletionCache
+from ..completions import ChatCompletionMessageParam, ChatCompletion
+
+
+# Types of cache modes:
+#
+# - skip_lookup: Don't look up keys in the cache, but write results to the
+#   cache.
+# - skip_all: Don't look up the cache, and don't store the result.
+# - normal: Look up the cache, and store the result if it's not in the cache.
+CacheMode = Literal["skip_lookup", "skip_all", "normal"]
+
+
+def request_cached_completion(
+    cache: Optional[ChatCompletionCache],
+    messages: List[ChatCompletionMessageParam],
+    completion_fn: Callable[[], ChatCompletion],
+    cache_mode: Optional[CacheMode],
+) -> ChatCompletion:
+    """Request a completion and optionally lookup/store it in the cache.
+
+    completion_fn should be a function that takes no arguments and returns a
+    ChatCompletion. In practice, you want to create a function that wraps the
+    real chat completion request function, and that function takes all its
+    needed arguments.
+    """
+    if cache is None:
+        return completion_fn()
+
+    cmpl = None
+    if cache_mode not in ("skip_lookup", "skip_all"):
+        cmpl = cache.get(messages)
+    if cmpl is None:
+        cmpl = completion_fn()
+        if cache_mode != "skip_all":
+            cache.set(messages, cmpl)
+
+    return cmpl

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -12,6 +12,7 @@ from ..completions import (
     ChatCompletionToolParam,
 )
 from ..workflow import SupportsWorkflow
+from ._shared import CacheMode
 
 
 class BaseAgent(Protocol):
@@ -26,6 +27,7 @@ class BaseAgent(Protocol):
         response_model: Optional[Any] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        cache_mode: Optional[CacheMode] = "normal",
         **kwargs: Any,
     ) -> ChatCompletion:
         """Create a completion
@@ -37,6 +39,12 @@ class BaseAgent(Protocol):
 
     def count_tokens(self, s: str) -> int:
         """Count the tokens in the string, according to the model's agent(s)"""
+
+    def set_cache_mode(self, mode: CacheMode) -> None:
+        """If the agent has a cache, set its cache mode"""
+
+    def get_cache_mode(self) -> CacheMode:
+        """If the agent has a cache, set its cache mode"""
 
 
 PreCompletionFn = Callable[

--- a/src/fixpoint/cache/__init__.py
+++ b/src/fixpoint/cache/__init__.py
@@ -1,0 +1,12 @@
+"""Caching of LLM inferences"""
+
+from typing import List
+
+from ..completions import ChatCompletion, ChatCompletionMessageParam
+from .protocol import SupportsCache
+from .tlru import TLRUCache
+from .disktlru import DiskTLRUCache
+
+ChatCompletionCache = SupportsCache[List[ChatCompletionMessageParam], ChatCompletion]
+
+__all__ = ["SupportsCache", "TLRUCache", "DiskTLRUCache", "ChatCompletionCache"]

--- a/src/fixpoint/cache/_shared.py
+++ b/src/fixpoint/cache/_shared.py
@@ -3,13 +3,20 @@
 import json
 from typing import Any
 
+from ..logging import logger as root_logger
+
+
+logger = root_logger.getChild("cache")
+
 
 def hash_key(key: Any) -> int:
     """Hash a key to an int"""
-    if isinstance(key, (dict, list, set)):
+    logger.debug("Hashing key of type: %s", type(key))
+    if isinstance(key, (dict, list, set, str)):
         # Convert unhashable types to a JSON string
         try:
             key_str = json.dumps(key, sort_keys=True)
+            logger.debug("Hashed key is: %s", key_str)
         except TypeError as e:
             # Handle types that are not serializable by json.dumps
             raise ValueError(f"Key of type {type(key)} is not serializable: {e}") from e

--- a/src/fixpoint/cache/disktlru.py
+++ b/src/fixpoint/cache/disktlru.py
@@ -5,9 +5,8 @@ from typing import Union, cast
 
 import diskcache
 
-from ..logging import logger
 from .protocol import SupportsCache, K_contra, V
-from ._shared import hash_key
+from ._shared import hash_key, logger
 
 # 50 MB
 _DEFAULT_SIZE_LIMIT_BYTES = 50 * 1024 * 1024
@@ -43,11 +42,19 @@ class DiskTLRUCache(SupportsCache[K_contra, V]):
 
     def get(self, key: K_contra) -> Union[V, None]:
         """Retrieve an item by key"""
-        return cast(Union[V, None], self._cache.get(hash_key(key)))
+        hashed = hash_key(key)
+        val = cast(Union[V, None], self._cache.get(hashed))
+        if val is None:
+            logger.debug("Cache miss for key: %d", hashed)
+        else:
+            logger.debug("Cache hit for key: %d", hashed)
+        return val
 
     def set(self, key: K_contra, value: V) -> None:
         """Set an item by key"""
-        self._cache.set(hash_key(key), value, expire=self._ttl_s)
+        hashed = hash_key(key)
+        logger.debug("Setting key: %d", hashed)
+        self._cache.set(hashed, value, expire=self._ttl_s)
 
     def delete(self, key: K_contra) -> None:
         """Delete an item by key"""

--- a/src/fixpoint/prompting/classification.py
+++ b/src/fixpoint/prompting/classification.py
@@ -11,7 +11,7 @@ from ..completions import (
     ChatCompletionToolParam,
 )
 from ..workflow.protocol import SupportsWorkflow
-from ..agents import BaseAgent
+from ..agents import BaseAgent, CacheMode
 from ..utils.messages import umsg
 
 
@@ -102,6 +102,7 @@ def classify_message(
     context_messages: Optional[List[ChatCompletionMessageParam]] = None,
     model: Optional[str] = None,
     workflow: Optional[SupportsWorkflow] = None,
+    cache_mode: Optional[CacheMode] = None
 ) -> ChatCompletion:
     """Classify a user message
 
@@ -125,6 +126,7 @@ def classify_message(
         messages=messages,
         tools=tools,
         tool_choice={"type": "function", "function": {"name": COT_CLASSIFY_TOOL_NAME}},
+        cache_mode=cache_mode,
     )
 
 
@@ -136,6 +138,7 @@ def create_classified_chat_completion(
     context_messages: Optional[List[ChatCompletionMessageParam]] = None,
     model: Optional[str] = None,
     workflow: Optional[SupportsWorkflow] = None,
+    cache_mode: Optional[CacheMode] = None
 ) -> ClassifiedChatCompletion:
     """Create a classified chat completion"""
     completion = classify_message(
@@ -145,5 +148,6 @@ def create_classified_chat_completion(
         model=model,
         workflow=workflow,
         context_messages=context_messages,
+        cache_mode=cache_mode,
     )
     return ClassifiedChatCompletion(completion=completion)

--- a/src/fixpoint_extras/services/formagent/setup.py
+++ b/src/fixpoint_extras/services/formagent/setup.py
@@ -2,8 +2,10 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Optional
 
 import fixpoint
+from fixpoint.cache import ChatCompletionCache
 from fixpoint.agents.protocol import TikTokenLogger
 from fixpoint.agents.openai import OpenAIClients
 from fixpoint.analyze.memory import DataframeMemory
@@ -21,9 +23,12 @@ class WorkflowContext:
     logger: logging.Logger
     memory: DataframeMemory
     workflow: fixpoint.workflow.SupportsWorkflow
+    cache: Optional[ChatCompletionCache]
 
 
-def setup_workflow(openai_key: str, model_name: str) -> WorkflowContext:
+def setup_workflow(
+    openai_key: str, model_name: str, cache: Optional[ChatCompletionCache] = None
+) -> WorkflowContext:
     """Set up the workflow context
 
     Set up the workflow context, which includes the workflow ojbect, the agent,
@@ -37,6 +42,7 @@ def setup_workflow(openai_key: str, model_name: str) -> WorkflowContext:
         openai_clients=OpenAIClients.from_api_key(openai_key),
         memory=agent_mem,
         pre_completion_fns=[tokenlogger.tiktoken_logger],
+        cache=cache,
     )
 
     workflow = fixpoint.workflow.Workflow(display_name="form filler agent workflow")
@@ -46,4 +52,5 @@ def setup_workflow(openai_key: str, model_name: str) -> WorkflowContext:
         memory=agent_mem,
         workflow=workflow,
         logger=logging.getLogger(f"fixpoint_workflow_{workflow.id}"),
+        cache=cache,
     )

--- a/src/fixpoint_extras/services/formagent/steps.py
+++ b/src/fixpoint_extras/services/formagent/steps.py
@@ -67,7 +67,8 @@ _INTAKE_PROMPT = jinja2.Template(
 
 
 def classify_form_type(
-    wfctx: WorkflowContext, user_message: str
+    wfctx: WorkflowContext,
+    user_message: str,
 ) -> Tuple[FormType, classification.ClassifiedChatCompletion]:
     """A workflow step that classifies the users message intent into a form type"""
     completion = classification.create_classified_chat_completion(


### PR DESCRIPTION
Allow us to control when an agent caches. We add a `CacheMode` parameter to the agent implementation classes, and also let the caller of `agent.create_completion` manually specify a cache mode override.

Also add some debug logging throughout the `fixpoint.cache` module. There is a `fixpoint.cache.logger` object so that you can control the log level for the caching, specifically.