### PR TITLE
Fix caching key stability bug

### DIFF
--- a/src/fixpoint/cache/_shared.py
+++ b/src/fixpoint/cache/_shared.py
@@ -9,17 +9,8 @@ from ..logging import logger as root_logger
 logger = root_logger.getChild("cache")
 
 
-def hash_key(key: Any) -> int:
-    """Hash a key to an int"""
-    logger.debug("Hashing key of type: %s", type(key))
-    if isinstance(key, (dict, list, set, str)):
-        # Convert unhashable types to a JSON string
-        try:
-            key_str = json.dumps(key, sort_keys=True)
-            logger.debug("Hashed key is: %s", key_str)
-        except TypeError as e:
-            # Handle types that are not serializable by json.dumps
-            raise ValueError(f"Key of type {type(key)} is not serializable: {e}") from e
-
-        return hash(key_str)
-    return hash(key)
+def serialize_any(key: Any) -> str:
+    """Serialize anything to a string"""
+    if isinstance(key, (dict, list, set, str, int, float, bool)):
+        return json.dumps(key)
+    return str(key)

--- a/src/fixpoint/cache/disktlru.py
+++ b/src/fixpoint/cache/disktlru.py
@@ -6,7 +6,7 @@ from typing import Union, cast
 import diskcache
 
 from .protocol import SupportsCache, K_contra, V
-from ._shared import hash_key, logger
+from ._shared import logger
 
 # 50 MB
 _DEFAULT_SIZE_LIMIT_BYTES = 50 * 1024 * 1024
@@ -42,23 +42,21 @@ class DiskTLRUCache(SupportsCache[K_contra, V]):
 
     def get(self, key: K_contra) -> Union[V, None]:
         """Retrieve an item by key"""
-        hashed = hash_key(key)
-        val = cast(Union[V, None], self._cache.get(hashed))
+        val = cast(Union[V, None], self._cache.get(key))
         if val is None:
-            logger.debug("Cache miss for key: %d", hashed)
+            logger.debug("Cache miss for key: %s", key)
         else:
-            logger.debug("Cache hit for key: %d", hashed)
+            logger.debug("Cache hit for key: %s", key)
         return val
 
     def set(self, key: K_contra, value: V) -> None:
         """Set an item by key"""
-        hashed = hash_key(key)
-        logger.debug("Setting key: %d", hashed)
-        self._cache.set(hashed, value, expire=self._ttl_s)
+        logger.debug("Setting key: %s", key)
+        self._cache.set(key, value, expire=self._ttl_s)
 
     def delete(self, key: K_contra) -> None:
         """Delete an item by key"""
-        self._cache.delete(hash_key(key))
+        self._cache.delete(key)
 
     def clear(self) -> None:
         """Clear all items from the cache"""

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 from freezegun import freeze_time
 
@@ -35,7 +36,7 @@ class TestMockAgent:
     def test_tlru_cache_ttl(self) -> None:
 
         cache = TLRUCache[List[ChatCompletionMessageParam], ChatCompletion](
-            maxsize=10, ttl=10
+            maxsize=10, ttl=10, serialize_key_fn=json.dumps
         )
 
         mock_gen = MockCompletionGenerator()

--- a/tests/cache/disktlru_test.py
+++ b/tests/cache/disktlru_test.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from fixpoint.cache import DiskTLRUCache
+from fixpoint.completions import ChatCompletionMessageParam
+
+
+class TestDiskTLRUCache:
+    def test_messages_serialize(self) -> None:
+        cache = DiskTLRUCache[List[ChatCompletionMessageParam], str].from_tmpdir(
+            size_limit_bytes=1024 * 1024, ttl_s=10
+        )
+
+        cache.set(
+            [{"role": "user", "content": "something goes here"}],
+            "this is a faked response",
+        )
+
+        # make sure that if we create a new list but it has the same contents,
+        # we get the same response
+        assert (
+            cache.get([{"role": "user", "content": "something goes here"}])
+            == "this is a faked response"
+        )

--- a/tests/cache/tlru_test.py
+++ b/tests/cache/tlru_test.py
@@ -1,3 +1,4 @@
+import json
 from freezegun import freeze_time
 from fixpoint.cache.tlru import TLRUCache
 
@@ -5,7 +6,7 @@ from fixpoint.cache.tlru import TLRUCache
 class TestTLRUCache:
 
     def test_tlru_cache_size_limits(self) -> None:
-        ttlCache = TLRUCache[str, str](maxsize=1, ttl=1000)
+        ttlCache = TLRUCache[str, str](maxsize=1, ttl=1000, serialize_key_fn=json.dumps)
         ttlCache.set("test", "a")
         ttlCache.set("test2", "b")
         ttlCache.set("test3", "c")
@@ -18,7 +19,7 @@ class TestTLRUCache:
 
     @freeze_time("2023-01-01")
     def test_tlru_cache_ttl(self) -> None:
-        ttlCache = TLRUCache[str, str](maxsize=1, ttl=10)
+        ttlCache = TLRUCache[str, str](maxsize=1, ttl=10, serialize_key_fn=json.dumps)
         ttlCache.set("test", "a")
         assert ttlCache.get("test") == "a"
 


### PR DESCRIPTION
The Python `hash` function is not stable across new instances of the Python VM. Furthermore, with some caches it would be useful to preserve the semantic meaning of the cache keys instead of randomizing them. For example, if we want to later add support to iterate over all cache key entries or do semantic caching.

To solve both these problems, we stop hashing with the builtin `hash` function to pseudo-random integers, and make these two changes:

1. The `DiskTLRUCache` requires you pass in a `serialize_key_fn` that converts the key to a string
2. The `DiskTLRUCache` doesn't do any special stuff, instead just using the implementations default pickling for serialization.