### PR TITLE
Allow caching of Pydantic models inside ChatCompletions

### DIFF
--- a/src/fixpoint/agents/_shared.py
+++ b/src/fixpoint/agents/_shared.py
@@ -22,7 +22,7 @@ def request_cached_completion(
     messages: List[ChatCompletionMessageParam],
     completion_fn: Callable[[], ChatCompletion],
     cache_mode: Optional[CacheMode],
-    structured_output_cls: Optional[Type[BaseModel]],
+    response_model: Optional[Type[BaseModel]],
 ) -> ChatCompletion:
     """Request a completion and optionally lookup/store it in the cache.
 
@@ -36,7 +36,7 @@ def request_cached_completion(
 
     cmpl = None
     if cache_mode not in ("skip_lookup", "skip_all"):
-        cmpl = cache.get(messages, structured_data_cls=structured_output_cls)
+        cmpl = cache.get(messages, structured_data_cls=response_model)
     if cmpl is None:
         cmpl = completion_fn()
         if cache_mode != "skip_all":

--- a/src/fixpoint/agents/_shared.py
+++ b/src/fixpoint/agents/_shared.py
@@ -1,8 +1,10 @@
 """Internal shared code for the "agents" module."""
 
-from typing import Callable, List, Optional, Literal
+from typing import Callable, List, Optional, Literal, Type
 
-from ..cache import ChatCompletionCache
+from pydantic import BaseModel
+
+from ..cache import SupportsChatCompletionCache
 from ..completions import ChatCompletionMessageParam, ChatCompletion
 
 
@@ -16,10 +18,11 @@ CacheMode = Literal["skip_lookup", "skip_all", "normal"]
 
 
 def request_cached_completion(
-    cache: Optional[ChatCompletionCache],
+    cache: Optional[SupportsChatCompletionCache],
     messages: List[ChatCompletionMessageParam],
     completion_fn: Callable[[], ChatCompletion],
     cache_mode: Optional[CacheMode],
+    structured_output_cls: Optional[Type[BaseModel]],
 ) -> ChatCompletion:
     """Request a completion and optionally lookup/store it in the cache.
 
@@ -33,7 +36,7 @@ def request_cached_completion(
 
     cmpl = None
     if cache_mode not in ("skip_lookup", "skip_all"):
-        cmpl = cache.get(messages)
+        cmpl = cache.get(messages, structured_data_cls=structured_output_cls)
     if cmpl is None:
         cmpl = completion_fn()
         if cache_mode != "skip_all":

--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -69,7 +69,7 @@ class MockAgent(BaseAgent):
             cache=self._cache,
             messages=messages,
             completion_fn=self._completion_fn,
-            structured_output_cls=response_model,
+            response_model=response_model,
         )
 
         if self._memory:

--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -1,12 +1,13 @@
 """Code for mocking out agents for testing."""
 
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional, Type
 
 from openai.types import CompletionUsage
 from openai.types.chat.chat_completion import (
     Choice as CompletionChoice,
     ChatCompletion as OpenAIChatCompletion,
 )
+from pydantic import BaseModel
 
 from ..completions import (
     ChatCompletion,
@@ -17,7 +18,7 @@ from ..completions import (
 )
 from ..memory import SupportsMemory
 from ..workflow import SupportsWorkflow
-from ..cache import ChatCompletionCache
+from ..cache import SupportsChatCompletionCache
 from .protocol import BaseAgent, CompletionCallback, PreCompletionFn
 from ._shared import request_cached_completion, CacheMode
 
@@ -37,7 +38,7 @@ class MockAgent(BaseAgent):
         pre_completion_fns: Optional[List[PreCompletionFn]] = None,
         completion_callbacks: Optional[List[CompletionCallback]] = None,
         memory: Optional[SupportsMemory] = None,
-        cache: Optional[ChatCompletionCache] = None,
+        cache: Optional[SupportsChatCompletionCache] = None,
     ):
         self._completion_fn = completion_fn
         self._pre_completion_fns = pre_completion_fns or []
@@ -51,7 +52,7 @@ class MockAgent(BaseAgent):
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
         workflow: Optional[SupportsWorkflow] = None,
-        response_model: Optional[Any] = None,
+        response_model: Optional[Type[BaseModel]] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
         cache_mode: Optional[CacheMode] = None,
@@ -68,6 +69,7 @@ class MockAgent(BaseAgent):
             cache=self._cache,
             messages=messages,
             completion_fn=self._completion_fn,
+            structured_output_cls=response_model,
         )
 
         if self._memory:

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -157,7 +157,7 @@ class OpenAIAgent(BaseAgent):
             messages=messages,
             completion_fn=_wrapped_completion_fn,
             cache_mode=cache_mode,
-            structured_output_cls=response_model,
+            response_model=response_model,
         )
 
         if self._memory is not None:

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -1,7 +1,8 @@
 """A base protocol for agents"""
 
-from typing import Any, Callable, Iterable, List, Optional, Protocol
+from typing import Any, Callable, Iterable, List, Optional, Protocol, Type
 
+from pydantic import BaseModel
 import tiktoken
 
 from ..logging import logger
@@ -24,7 +25,7 @@ class BaseAgent(Protocol):
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
         workflow: Optional[SupportsWorkflow] = None,
-        response_model: Optional[Any] = None,
+        response_model: Optional[Type[BaseModel]] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
         cache_mode: Optional[CacheMode] = "normal",

--- a/src/fixpoint/cache/__init__.py
+++ b/src/fixpoint/cache/__init__.py
@@ -2,11 +2,13 @@
 
 from typing import List
 
-from ..completions import ChatCompletion, ChatCompletionMessageParam
-from .protocol import SupportsCache
-from .tlru import TLRUCache
-from .disktlru import DiskTLRUCache
+from .protocol import SupportsCache, SupportsChatCompletionCache
+from .tlru import ChatCompletionTLRUCache
+from .disktlru import ChatCompletionDiskTLRUCache
 
-ChatCompletionCache = SupportsCache[List[ChatCompletionMessageParam], ChatCompletion]
-
-__all__ = ["SupportsCache", "TLRUCache", "DiskTLRUCache", "ChatCompletionCache"]
+__all__ = [
+    "SupportsCache",
+    "ChatCompletionTLRUCache",
+    "ChatCompletionDiskTLRUCache",
+    "SupportsChatCompletionCache",
+]

--- a/src/fixpoint/cache/protocol.py
+++ b/src/fixpoint/cache/protocol.py
@@ -1,6 +1,12 @@
 """Protocol definitions for various cache types"""
 
-from typing import Protocol, TypeVar, Union, Any
+from typing import List, Optional, Protocol, TypeVar, Union, Any, Type
+
+from pydantic import BaseModel
+
+from fixpoint.completions.chat_completion import ChatCompletion
+from fixpoint.completions.chat_completion import ChatCompletionMessageParam
+
 
 # Rename K to K_contra to indicate contravariance
 K_contra = TypeVar("K_contra", contravariant=True)  # Key type
@@ -29,6 +35,22 @@ class SupportsCache(Protocol[K_contra, V]):
     @property
     def currentsize(self) -> int:
         """Property to get the currentsize of the cache"""
+
+
+# Pydantic models do not pickle well, so make a class that serializes and
+# deserializes the ChatCompletion. To do deserialization, we need to know the
+# BaseModel class to use.
+class SupportsChatCompletionCache(
+    SupportsCache[List[ChatCompletionMessageParam], ChatCompletion], Protocol
+):
+    """A cache protocol for chat completions"""
+
+    def get(
+        self,
+        key: List[ChatCompletionMessageParam],
+        structured_data_cls: Optional[Type[BaseModel]] = None,
+    ) -> Union[ChatCompletion, None]:
+        """Retrieve an item by key, optionally populating the structured output field"""
 
 
 class SupportCacheItem(Protocol):

--- a/src/fixpoint/completions/chat_completion.py
+++ b/src/fixpoint/completions/chat_completion.py
@@ -25,11 +25,6 @@ def _raw_set_attr(obj: Any, name: str, value: Any) -> None:
     object.__setattr__(obj, name, value)
 
 
-# value.to_json()
-# value.model_dump_json()
-# value.model_validate_json()
-
-
 class ChatCompletion(OpenAIChatCompletion):
     """
     A class that wraps a completion with a Fixpoint completion.

--- a/src/fixpoint_extras/services/formagent/setup.py
+++ b/src/fixpoint_extras/services/formagent/setup.py
@@ -4,7 +4,7 @@ import logging
 from typing import Mapping, Optional
 
 import fixpoint
-from fixpoint.cache import ChatCompletionCache
+from fixpoint.cache import SupportsChatCompletionCache
 from fixpoint.agents.protocol import TikTokenLogger
 from fixpoint.agents.openai import OpenAIClients
 from fixpoint.analyze.memory import DataframeMemory
@@ -14,7 +14,7 @@ from .workflowcontext import WorkflowContext
 def setup_workflow(
     openai_key: str,
     model_name: str,
-    cache: Optional[ChatCompletionCache] = None,
+    cache: Optional[SupportsChatCompletionCache] = None,
     openai_base_url: Optional[str] = None,
     default_openai_headers: Optional[Mapping[str, str]] = None,
 ) -> WorkflowContext:

--- a/src/fixpoint_extras/services/formagent/workflowcontext.py
+++ b/src/fixpoint_extras/services/formagent/workflowcontext.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional
 
 import fixpoint
-from fixpoint.cache import ChatCompletionCache
+from fixpoint.cache import SupportsChatCompletionCache
 from fixpoint.analyze.memory import DataframeMemory
 
 
@@ -21,4 +21,4 @@ class WorkflowContext:
     logger: logging.Logger
     memory: DataframeMemory
     workflow: fixpoint.workflow.SupportsWorkflow
-    cache: Optional[ChatCompletionCache]
+    cache: Optional[SupportsChatCompletionCache]

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -6,7 +6,7 @@ from fixpoint.completions import ChatCompletion, ChatCompletionMessageParam
 from fixpoint.agents.mock import MockAgent, new_mock_completion
 from fixpoint.memory import Memory
 from fixpoint.utils import messages
-from fixpoint.cache.tlru import TLRUCache
+from fixpoint.cache.tlru import ChatCompletionTLRUCache
 
 
 class TestMockAgent:
@@ -35,9 +35,7 @@ class TestMockAgent:
     @freeze_time("2023-01-01 00:00:00")
     def test_tlru_cache_ttl(self) -> None:
 
-        cache = TLRUCache[List[ChatCompletionMessageParam], ChatCompletion](
-            maxsize=10, ttl=10, serialize_key_fn=json.dumps
-        )
+        cache = ChatCompletionTLRUCache(maxsize=10, ttl=10, serialize_key_fn=json.dumps)
 
         mock_gen = MockCompletionGenerator()
         agent = MockAgent(completion_fn=mock_gen.new_mock_completion, cache=cache)

--- a/tests/agents/openai_test.py
+++ b/tests/agents/openai_test.py
@@ -47,7 +47,7 @@ class TestAgents:
             messages: Any, response_model: Any
         ) -> tuple[SampleStructure, OpenAIChatCompletion]:
             completion = new_mock_orig_completion("I'm doing good.")
-            structure = SampleStructure("John")
+            structure = SampleStructure(name="John")
 
             # Return in order instructor expects them
             return structure, completion
@@ -71,4 +71,5 @@ class TestAgents:
 
             assert response.choices[0].message.content == "I'm doing good."
             assert response.fixp.structured_output is not None
+            assert isinstance(response.fixp.structured_output, SampleStructure)
             assert response.fixp.structured_output.name == "John"

--- a/tests/cache/disktlru_test.py
+++ b/tests/cache/disktlru_test.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fixpoint.cache import DiskTLRUCache
+from fixpoint.cache.disktlru import DiskTLRUCache
 from fixpoint.completions import ChatCompletionMessageParam
 
 

--- a/tests/completions/completions_test.py
+++ b/tests/completions/completions_test.py
@@ -1,14 +1,18 @@
+import json
+
+from pydantic import BaseModel
+
 from fixpoint.completions import ChatCompletion
 from fixpoint.agents.mock import new_mock_orig_completion
-from tests.test_utils import SampleStructure
+
+from ..test_utils import SampleStructure
 
 
-class TestCompletions:
-
+class TestChatCompletion:
     def test_fixpoint_completions(self) -> None:
 
         greeting_completion = new_mock_orig_completion(content="I'm doing good.")
-        greeting_structure = SampleStructure("John")
+        greeting_structure = SampleStructure(name="John")
 
         fixpoint_completion = ChatCompletion.from_original_completion(
             greeting_completion, greeting_structure
@@ -21,3 +25,26 @@ class TestCompletions:
         assert isinstance(fixpoint_completion.fixp, ChatCompletion.Fixp)
         assert isinstance(fixpoint_completion.fixp.structured_output, SampleStructure)
         assert fixpoint_completion.fixp.structured_output.name == "John"
+
+    def test_model_serialization(self) -> None:
+        orig_completion = new_mock_orig_completion()
+        structured_out = ExampleStructuredOutput(name="Dylan", age=9000)
+        completion = ChatCompletion.from_original_completion(
+            orig_completion, structured_out
+        )
+
+        jsondata = completion.serialize_json()
+        jsondict = json.loads(jsondata)
+        assert jsondict["fixp"]["structured_output"] == {"name": "Dylan", "age": 9000}
+
+        loaded_completion = ChatCompletion.deserialize_json(
+            jsondata, ExampleStructuredOutput
+        )
+
+        assert loaded_completion.choices == completion.choices
+        assert loaded_completion.fixp.structured_output == structured_out
+
+
+class ExampleStructuredOutput(BaseModel):
+    name: str
+    age: int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
-class SampleStructure:
-    def __init__(self, name: str) -> None:
-        self.name = name
+from pydantic import BaseModel
+
+
+class SampleStructure(BaseModel):
+    name: str

--- a/tests/utils/completions_test.py
+++ b/tests/utils/completions_test.py
@@ -14,7 +14,7 @@ class TestUtilsCompletions:
             _prompt: str, _response_type: SampleStructure
         ) -> tuple[SampleStructure, OpenAIChatCompletion]:
             completion = new_mock_orig_completion(content="I'm doing good.")
-            structure = SampleStructure("John")
+            structure = SampleStructure(name="John")
 
             # Return in order instructor expects them
             return structure, completion


### PR DESCRIPTION
When we try to cache a ChatCompletion to disk, if it has an inner "structured output" Pydantic model, then the `DiskCache` throws an error when trying to pickle the object. It's possible this error is just related to slightly different import paths on cache save versus load, but regardless, saving pickled objects is not a good strategy.

So we add support for serializing a ChatCompletion to disk as JSON, and loading it back in as JSON. When we load it back in as JSON, we don't know what `Pydantic` class to use for the structured output, so we extended the caching classes to accept a Pydantic class when calling `get`. This was added to a new protocol, `SupportsChatCompletionCache`.

Most of the rest of this commit is just fixing all of the plumbing for caching to use the new `SupportsChatCompletionCache` and pass in the Pydantic module to the cache when available.

Later, we should probably consider making private the generic `SupportsCache` and its generic class implementations. There is no need to expose them publicly, and we don't want to use them anyways, when interacting with LLM inference, since we always use a cache that is specifically for input/output inference messages.