### PR TITLE
ChatCompletion has generic type for structured output

### DIFF
--- a/src/fixpoint/_utils/completions.py
+++ b/src/fixpoint/_utils/completions.py
@@ -2,14 +2,18 @@
 Utilities for completions.
 """
 
-from typing import Callable, Any
+from typing import Callable, Any, Tuple
 from functools import wraps
+
+from openai.types.chat.chat_completion import ChatCompletion as OpenAIChatCompletion
+from pydantic import BaseModel
+
 from ..completions import ChatCompletion
 
 
 def decorate_instructor_completion_with_fixp(
-    func: Callable[..., Any]
-) -> Callable[..., Any]:
+    func: Callable[..., Tuple[BaseModel, OpenAIChatCompletion]]
+) -> Callable[..., ChatCompletion[BaseModel]]:
     """
     Decorate the completion method to replace the original
     completion object with our Fixpoint ChatCompletion.
@@ -22,7 +26,7 @@ def decorate_instructor_completion_with_fixp(
 
         # Wrap the completion object with Fixpoint ChatCompletion and
         # inject additional information under .fixp attribute
-        fixpoint_completion = ChatCompletion.from_original_completion(
+        fixpoint_completion = ChatCompletion[BaseModel].from_original_completion(
             completion, structured_output
         )
 

--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -1,6 +1,16 @@
 """Code for mocking out agents for testing."""
 
-from typing import Any, Callable, Iterable, List, Optional, Type, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from openai.types import CompletionUsage
 from openai.types.chat.chat_completion import (
@@ -48,6 +58,34 @@ class MockAgent(BaseAgent):
         self._completion_callbacks = completion_callbacks or []
         self._memory = memory
         self._cache = cache
+
+    @overload
+    def create_completion(
+        self,
+        *,
+        messages: List[ChatCompletionMessageParam],
+        response_model: None = None,
+        model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
+        tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
+        tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        cache_mode: Optional[CacheMode] = None,
+        **kwargs: Any,
+    ) -> ChatCompletion[BaseModel]: ...
+
+    @overload
+    def create_completion(
+        self,
+        *,
+        messages: List[ChatCompletionMessageParam],
+        response_model: Type[T_contra],
+        model: Optional[str] = None,
+        workflow: Optional[SupportsWorkflow] = None,
+        tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
+        tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        cache_mode: Optional[CacheMode] = None,
+        **kwargs: Any,
+    ) -> ChatCompletion[T_contra]: ...
 
     def create_completion(
         self,

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
     get_args,
     cast,
+    overload,
 )
 
 import openai
@@ -336,14 +337,40 @@ class OpenAI:
             # Forward attribute access to the underlying client
             return getattr(self._fixpcompletions, name)
 
+        @overload
         def create(
             self,
             messages: List[ChatCompletionMessageParam],
             *,
+            response_model: None = None,
             model: Optional[str] = None,
             tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
             tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+            workflow: Optional[SupportsWorkflow] = None,
+            **kwargs: Any,
+        ) -> ChatCompletion[BaseModel]: ...
+
+        @overload
+        def create(
+            self,
+            messages: List[ChatCompletionMessageParam],
+            *,
+            response_model: Type[T_contra],
+            model: Optional[str] = None,
+            tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
+            tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+            workflow: Optional[SupportsWorkflow] = None,
+            **kwargs: Any,
+        ) -> ChatCompletion[T_contra]: ...
+
+        def create(
+            self,
+            messages: List[ChatCompletionMessageParam],
+            *,
             response_model: Optional[Type[T_contra]] = None,
+            model: Optional[str] = None,
+            tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
+            tools: Optional[Iterable[ChatCompletionToolParam]] = None,
             workflow: Optional[SupportsWorkflow] = None,
             **kwargs: Any,
         ) -> ChatCompletion[T_contra]:

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -4,7 +4,18 @@ interaction between the user and OpenAI.
 """
 
 from dataclasses import dataclass
-from typing import Any, Iterable, List, Mapping, Optional, Type, Union, get_args, cast
+from typing import (
+    Any,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    cast,
+)
 
 import openai
 from pydantic import BaseModel
@@ -83,6 +94,9 @@ class OpenAIClients:
     #         instructor_client.default_headers = default_headers
 
 
+T_contra = TypeVar("T_contra", bound=BaseModel, contravariant=True)
+
+
 class OpenAIAgent(BaseAgent):
     """
     An agent that follows our BaseAgent protocol, but interacts with OpenAI.
@@ -124,12 +138,12 @@ class OpenAIAgent(BaseAgent):
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
         workflow: Optional[SupportsWorkflow] = None,
-        response_model: Optional[Type[BaseModel]] = None,
+        response_model: Optional[Type[T_contra]] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
         cache_mode: Optional[CacheMode] = None,
         **kwargs: Any,
-    ) -> ChatCompletion:
+    ) -> ChatCompletion[T_contra]:
         """Create a completion"""
         if "stream" in kwargs and kwargs["stream"]:
             raise ValueError("Streaming is not supported yet.")
@@ -140,7 +154,7 @@ class OpenAIAgent(BaseAgent):
         # constructed the agent with.
         mymodel = model or self.model_name
 
-        def _wrapped_completion_fn() -> ChatCompletion:
+        def _wrapped_completion_fn() -> ChatCompletion[T_contra]:
             return self._request_completion(
                 messages,
                 mymodel,
@@ -160,20 +174,21 @@ class OpenAIAgent(BaseAgent):
             response_model=response_model,
         )
 
+        basemodel_fixp_completion = cast(ChatCompletion[BaseModel], fixp_completion)
         if self._memory is not None:
-            self._memory.store_memory(messages, fixp_completion, workflow)
-        self._trigger_completion_callbacks(messages, fixp_completion)
+            self._memory.store_memory(messages, basemodel_fixp_completion, workflow)
+        self._trigger_completion_callbacks(messages, basemodel_fixp_completion)
         return fixp_completion
 
     def _request_completion(
         self,
         messages: List[ChatCompletionMessageParam],
         model: str,
-        response_model: Optional[Type[BaseModel]] = None,
+        response_model: Optional[Type[T_contra]] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
         **kwargs: Any,
-    ) -> ChatCompletion:
+    ) -> ChatCompletion[T_contra]:
         if response_model is None:
             compl = self._openai_clients.openai.chat.completions.create(
                 messages=messages,
@@ -237,7 +252,9 @@ class OpenAIAgent(BaseAgent):
     # `self.chat.completions.create` because that is a blind pass-through call
     # to the OpenAI client class, so we have no way to control it.
     def _trigger_completion_callbacks(
-        self, messages: List[ChatCompletionMessageParam], completion: ChatCompletion
+        self,
+        messages: List[ChatCompletionMessageParam],
+        completion: ChatCompletion[BaseModel],
     ) -> None:
         """Trigger the completion callbacks"""
         for callback in self._completion_callbacks:
@@ -326,10 +343,10 @@ class OpenAI:
             model: Optional[str] = None,
             tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
             tools: Optional[Iterable[ChatCompletionToolParam]] = None,
-            response_model: Optional[Type[BaseModel]] = None,
+            response_model: Optional[Type[T_contra]] = None,
             workflow: Optional[SupportsWorkflow] = None,
             **kwargs: Any,
-        ) -> ChatCompletion:
+        ) -> ChatCompletion[T_contra]:
             """Create a chat completion"""
             return self._agent.create_completion(
                 messages=messages,

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -1,6 +1,6 @@
 """A base protocol for agents"""
 
-from typing import Any, Callable, Iterable, List, Optional, Protocol, Type
+from typing import Any, Callable, Iterable, List, Optional, Protocol, Type, TypeVar
 
 from pydantic import BaseModel
 import tiktoken
@@ -16,6 +16,9 @@ from ..workflow import SupportsWorkflow
 from ._shared import CacheMode
 
 
+T_contra = TypeVar("T_contra", bound=BaseModel, contravariant=True)
+
+
 class BaseAgent(Protocol):
     """The base protocol for agents"""
 
@@ -25,12 +28,12 @@ class BaseAgent(Protocol):
         messages: List[ChatCompletionMessageParam],
         model: Optional[str] = None,
         workflow: Optional[SupportsWorkflow] = None,
-        response_model: Optional[Type[BaseModel]] = None,
+        response_model: Optional[Type[T_contra]] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
         cache_mode: Optional[CacheMode] = "normal",
         **kwargs: Any,
-    ) -> ChatCompletion:
+    ) -> ChatCompletion[T_contra]:
         """Create a completion
 
         The `model` argument is optional if the agent has a pre-defined model it
@@ -52,7 +55,9 @@ PreCompletionFn = Callable[
     [List[ChatCompletionMessageParam]], List[ChatCompletionMessageParam]
 ]
 
-CompletionCallback = Callable[[List[ChatCompletionMessageParam], ChatCompletion], None]
+CompletionCallback = Callable[
+    [List[ChatCompletionMessageParam], ChatCompletion[BaseModel]], None
+]
 
 
 class TikTokenLogger:

--- a/src/fixpoint/cache/protocol.py
+++ b/src/fixpoint/cache/protocol.py
@@ -37,19 +37,22 @@ class SupportsCache(Protocol[K_contra, V]):
         """Property to get the currentsize of the cache"""
 
 
+T = TypeVar("T", bound=BaseModel)
+
+
 # Pydantic models do not pickle well, so make a class that serializes and
 # deserializes the ChatCompletion. To do deserialization, we need to know the
 # BaseModel class to use.
 class SupportsChatCompletionCache(
-    SupportsCache[List[ChatCompletionMessageParam], ChatCompletion], Protocol
+    SupportsCache[List[ChatCompletionMessageParam], ChatCompletion[BaseModel]], Protocol
 ):
     """A cache protocol for chat completions"""
 
     def get(
         self,
         key: List[ChatCompletionMessageParam],
-        structured_data_cls: Optional[Type[BaseModel]] = None,
-    ) -> Union[ChatCompletion, None]:
+        response_model: Optional[Type[T]] = None,
+    ) -> Union[ChatCompletion[T], None]:
         """Retrieve an item by key, optionally populating the structured output field"""
 
 

--- a/src/fixpoint/cache/tlru.py
+++ b/src/fixpoint/cache/tlru.py
@@ -4,7 +4,7 @@ TLRU Cache
 
 import time
 from threading import RLock
-from typing import Any, Callable, List, Union, Optional, Type, cast
+from typing import Any, Callable, List, Union, Optional, Type, TypeVar, cast
 from cachetools import TLRUCache as CachetoolsTLRUCache
 
 from pydantic import BaseModel
@@ -117,8 +117,11 @@ class TLRUCache(SupportsCache[K_contra, V]):
             return int(self.cache.maxsize)
 
 
+T = TypeVar("T", bound=BaseModel)
+
+
 class ChatCompletionTLRUCache(
-    TLRUCache[List[ChatCompletionMessageParam], ChatCompletion],
+    TLRUCache[List[ChatCompletionMessageParam], ChatCompletion[BaseModel]],
     SupportsChatCompletionCache,
 ):
     """A TLRU cache for LLM inference requests"""
@@ -127,8 +130,8 @@ class ChatCompletionTLRUCache(
         self,
         key: List[ChatCompletionMessageParam],
         # pylint: disable=unused-argument
-        structured_data_cls: Optional[Type[BaseModel]] = None,
-    ) -> Union[ChatCompletion, None]:
+        response_model: Optional[Type[T]] = None,
+    ) -> Union[ChatCompletion[T], None]:
         # this cache doesn't need to serialize/deserialize anything because
         # we're in the Python memory. So we can ignore the structured_data_cls
-        return cast(ChatCompletion, super().get(key))
+        return cast(ChatCompletion[T], super().get(key))

--- a/src/fixpoint/memory/_memory.py
+++ b/src/fixpoint/memory/_memory.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import List, Protocol, Optional
 
+from pydantic import BaseModel
+
 from ..completions import ChatCompletionMessageParam, ChatCompletion
 from ..workflow import SupportsWorkflow
 
@@ -12,7 +14,7 @@ class MemoryItem:
     """A single memory item"""
 
     messages: List[ChatCompletionMessageParam]
-    completion: ChatCompletion
+    completion: ChatCompletion[BaseModel]
     workflow: Optional[SupportsWorkflow] = None
 
 
@@ -25,7 +27,7 @@ class SupportsMemory(Protocol):
     def store_memory(
         self,
         messages: List[ChatCompletionMessageParam],
-        completion: ChatCompletion,
+        completion: ChatCompletion[BaseModel],
         workflow: Optional[SupportsWorkflow] = None,
     ) -> None:
         """Store the memory"""
@@ -45,7 +47,7 @@ class Memory(SupportsMemory):
     def store_memory(
         self,
         messages: List[ChatCompletionMessageParam],
-        completion: ChatCompletion,
+        completion: ChatCompletion[BaseModel],
         workflow: Optional[SupportsWorkflow] = None,
     ) -> None:
         """Store the memory

--- a/src/fixpoint/prompting/classification.py
+++ b/src/fixpoint/prompting/classification.py
@@ -4,6 +4,7 @@ import json
 from typing import Any, Dict, List, Optional, TypedDict
 
 import jinja2
+from pydantic import BaseModel
 
 from ..completions import (
     ChatCompletionMessageParam,
@@ -79,11 +80,11 @@ def _make_cot_classes(choices: List[Choice]) -> List[Dict[str, Any]]:
 class ClassifiedChatCompletion:
     """A classified chat completion"""
 
-    completion: ChatCompletion
+    completion: ChatCompletion[BaseModel]
     chain_of_thought: str
     classification: str
 
-    def __init__(self, completion: ChatCompletion):
+    def __init__(self, completion: ChatCompletion[BaseModel]):
         self.completion = completion
         tool_calls = completion.choices[0].message.tool_calls
         if tool_calls is None:
@@ -103,7 +104,7 @@ def classify_message(
     model: Optional[str] = None,
     workflow: Optional[SupportsWorkflow] = None,
     cache_mode: Optional[CacheMode] = None
-) -> ChatCompletion:
+) -> ChatCompletion[BaseModel]:
     """Classify a user message
 
     agent: the agent to use for the classification

--- a/src/fixpoint_extras/services/formagent/tasks/invoice.py
+++ b/src/fixpoint_extras/services/formagent/tasks/invoice.py
@@ -38,7 +38,7 @@ class InvoiceQuestions(BaseModel):
 
 def answer_invoice_questions(
     wfctx: WorkflowContext, user_message: str
-) -> Tuple[InvoiceQuestions, ChatCompletion]:
+) -> Tuple[InvoiceQuestions, ChatCompletion[InvoiceQuestions]]:
     """Answer the questions about the invoice."""
     completion = wfctx.agent.create_completion(
         messages=[

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -2,6 +2,8 @@ import json
 from typing import List
 from freezegun import freeze_time
 
+from pydantic import BaseModel
+
 from fixpoint.completions import ChatCompletion, ChatCompletionMessageParam
 from fixpoint.agents.mock import MockAgent, new_mock_completion
 from fixpoint.memory import Memory
@@ -17,7 +19,7 @@ class TestMockAgent:
         )
 
         assert mem.memory() == []
-        cmpl = agent.create_completion(
+        cmpl: ChatCompletion[BaseModel] = agent.create_completion(
             messages=[
                 messages.smsg("I am a system"),
                 messages.umsg("I am a user"),
@@ -47,7 +49,7 @@ class TestMockAgent:
             messages.smsg("I am a system"),
             messages.umsg("I am a user"),
         ]
-        cmpl = agent.create_completion(messages=msgs)
+        cmpl: ChatCompletion[BaseModel] = agent.create_completion(messages=msgs)
         assert cmpl.choices[0].message.content == "test 0"
         assert cache.currentsize == 1
         assert cache.maxsize == 10
@@ -74,7 +76,7 @@ class MockCompletionGenerator:
     def __init__(self) -> None:
         self._num = 0
 
-    def new_mock_completion(self) -> ChatCompletion:
+    def new_mock_completion(self) -> ChatCompletion[BaseModel]:
         cmpl = new_mock_completion(content=f"test {self._num}")
         self._num += 1
         return cmpl

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -19,7 +19,7 @@ class TestMockAgent:
         )
 
         assert mem.memory() == []
-        cmpl: ChatCompletion[BaseModel] = agent.create_completion(
+        cmpl = agent.create_completion(
             messages=[
                 messages.smsg("I am a system"),
                 messages.umsg("I am a user"),
@@ -49,7 +49,7 @@ class TestMockAgent:
             messages.smsg("I am a system"),
             messages.umsg("I am a user"),
         ]
-        cmpl: ChatCompletion[BaseModel] = agent.create_completion(messages=msgs)
+        cmpl = agent.create_completion(messages=msgs)
         assert cmpl.choices[0].message.content == "test 0"
         assert cache.currentsize == 1
         assert cache.maxsize == 10

--- a/tests/memory/test_memgpt.py
+++ b/tests/memory/test_memgpt.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from pydantic import BaseModel
+
 from fixpoint.memory import Memory
 from fixpoint.completions import ChatCompletion, ChatCompletionMessageParam
 from fixpoint.agents.mock import MockAgent, new_mock_completion
@@ -18,7 +20,7 @@ class TestMemGPTSummaryAgent:
         summary_opts = MemGPTSummarizeOpts(agent=agent, context_window=200)
         summary_agent = MemGPTSummaryAgent(summary_opts)
 
-        compl = summary_agent.create_completion(
+        compl: ChatCompletion[BaseModel] = summary_agent.create_completion(
             messages=[
                 smsg(
                     "You are a friendly AI customer support agent. You chat with a user to answer their questions"
@@ -58,7 +60,7 @@ def test_context_length_check() -> None:
     assert len(extra_messages) == 2
 
 
-def _completion_fn() -> ChatCompletion:
+def _completion_fn() -> ChatCompletion[BaseModel]:
     return new_mock_completion(
         "I am a friendly AI customer support agent here to assist you with any questions or issues you may have. How can I help you today?"
     )

--- a/tests/memory/test_memgpt.py
+++ b/tests/memory/test_memgpt.py
@@ -20,7 +20,7 @@ class TestMemGPTSummaryAgent:
         summary_opts = MemGPTSummarizeOpts(agent=agent, context_window=200)
         summary_agent = MemGPTSummaryAgent(summary_opts)
 
-        compl: ChatCompletion[BaseModel] = summary_agent.create_completion(
+        compl = summary_agent.create_completion(
             messages=[
                 smsg(
                     "You are a friendly AI customer support agent. You chat with a user to answer their questions"


### PR DESCRIPTION
Change the `ChatCompletion` class definition so that it accepts a generic type that can be any subclass of `pydantic.BaseModel`. This is the type of the structured data that the `ChatCompletion` can optionally hold.

Then I had to wire up the generics across the codebase when using chat completions. It would be nice if we could make the generic type optional by giving it a default type of `BaseModel`, but we'll need to wait for PEP-696 for that.[1]

Initially, whenever I called `create_completion` without specifying a `response_model` argument, we had to annotate the return type with `ChatCompletion[BaseModel]`. This was annoying. PEP-696 would have fixed this, but an alternative fix we can do right now is to overload the `BaseAgent.create_completion` definition so that we can better infer the return type based on whether the user specifies a `response_model` type or not.

The end result is the user doesn't need to annotate the returned `ChatCompletion` types.

[1]: https://peps.python.org/pep-0696/