### PR TITLE
Add an InfoGatherer controller

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -436,7 +436,8 @@ disable=raw-checker-failed,
         too-many-arguments,
         too-many-instance-attributes,
         too-many-return-statements,
-        no-else-return
+        no-else-return,
+        consider-iterating-dictionary
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/fixpoint_extras/services/formagent/controllers/__init__.py
+++ b/src/fixpoint_extras/services/formagent/controllers/__init__.py
@@ -1,0 +1,24 @@
+"""
+A controller can be thought of a controller (duh) or a manager of other AI
+agents and the process for how they work together to accomplish something. It's
+a higher level way to compose and coordiante agents.
+
+In some cases, there can be overlap of responsibility between "agents" and
+"controllers", but we think of the difference like this:
+
+Agents are backed by some AI, and they can take multiple steps, but generally
+you just ask the agent to accomplish something and it does it.
+
+Controllers can layer on top of a single agent, or can coordinate multiple
+agents, and expose interfaces designed to be controlled by our software systems
+or other AIs. They are meta-agents that coordinate or modify the behavior of
+other agent(s) and let those agents easily integrate with other software
+systems.
+
+In general, controllers do not have a uniform interface between controllers.
+
+It looks like this "AI controller" nomenclature is being explored in other
+places:
+
+https://www.microsoft.com/en-us/research/blog/ai-controller-interface-generative-ai-with-a-lightweight-llm-integrated-vm/
+"""

--- a/src/fixpoint_extras/services/formagent/controllers/infogather.py
+++ b/src/fixpoint_extras/services/formagent/controllers/infogather.py
@@ -1,0 +1,157 @@
+"""A controller that gathers info in order to fill out a form."""
+
+from typing import Any, Dict, List, Type, Generic, TypeVar, Optional
+
+from pydantic import BaseModel, Field, create_model
+from pydantic.fields import FieldInfo
+
+from fixpoint.utils.messages import umsg
+from fixpoint.completions import ChatCompletionMessageParam, ChatCompletion
+from fixpoint.agents import BaseAgent
+
+
+_QUESTION_FIELD_PREFIX = "question_"
+_QUESTION_FIELD_PREFIX_LEN = len(_QUESTION_FIELD_PREFIX)
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class InfoGatherer(Generic[T]):
+    """A controller that gathers info in order to fill out a form."""
+
+    agent: BaseAgent
+    info_model: Type[T]
+    info: T
+    # A history of all info objects, including the latest. AKA,
+    # `self.info_history[-1] == self.info`
+    info_history: List[T]
+    _questions: Dict[str, str]
+
+    def __init__(self, info_model: Type[T], agent: BaseAgent):
+        self.agent = agent
+        self.info = info_model()
+        self.info_model = info_model
+        self.info_history = [self.info]
+        self._questions = self.make_field_questions()
+
+    def _make_questions_model(self) -> Type[BaseModel]:
+        # type-checking the `create_model` is weird, so just ignore it
+        new_fields: Dict[str, Any] = {}
+        for k, v in self.info_model.model_fields.items():
+            new_fields[f"{_QUESTION_FIELD_PREFIX}{k}"] = (
+                str,
+                Field(description=f"Question for: {v.description}"),
+            )
+
+        # We want to use a class-style variable name here, which Pylint normally
+        # complains about.
+        # pylint: disable=invalid-name
+        InfoGathererQuestions: Type[BaseModel] = create_model(
+            "InfoGathererQuestions", **new_fields
+        )
+        return InfoGathererQuestions
+
+    def make_field_questions(self, agent: Optional[BaseAgent] = None) -> Dict[str, str]:
+        """Make a question for every info field.
+
+        The info fields are often not formatted as questions. This generates a
+        list of questions, one for every info field.
+        """
+        if not agent:
+            agent = self.agent
+        questions_model = self._make_questions_model()
+        field_descs = "\n".join(
+            [
+                # Ideally every field should have a description. If it's
+                # missing, just use the field name.
+                (v.description if v.description else k)
+                for k, v in self.info_model.model_fields.items()
+            ]
+        )
+        prompt = (
+            "Below are a series of form field descriptions, one per line.\n"
+            "\n"
+            f"{field_descs}\n"
+            "\n"
+            "For each form field, write a short question that asks a person for the "
+            'field\'s value. Do not prefix each question with "Question:" or '
+            "anything similar."
+        )
+        cmpl = agent.create_completion(
+            messages=[umsg(prompt)], response_model=questions_model
+        )
+        sout = cmpl.fixp.structured_output
+        if sout is None:
+            raise ValueError("No structured output found in completion")
+
+        out_dict = sout.model_dump()
+        # every question key was prefixed with "question_". Remove that prefix
+        return {k[_QUESTION_FIELD_PREFIX_LEN:]: v for k, v in out_dict.items()}
+
+    def missing_fields(self) -> Dict[str, FieldInfo]:
+        """Get the fields that do not yet have answers."""
+        missing: Dict[str, FieldInfo] = {}
+        for k, v in self.info.model_dump().items():
+            if v is None:
+                missing[k] = self.info_model.model_fields[k]
+        return missing
+
+    def is_complete(self) -> bool:
+        """True if all form info has been filled in."""
+        missing = self.missing_fields()
+        return len(missing) == 0
+
+    def process_messages(
+        self,
+        messages: List[ChatCompletionMessageParam],
+        agent: Optional[BaseAgent] = None,
+    ) -> ChatCompletion[T]:
+        """Process a user's message and update the form info."""
+        if not agent:
+            agent = self.agent
+        old_info = self.info
+        completion = agent.create_completion(
+            messages=messages, response_model=self.info_model
+        )
+
+        # get the non-None fields from the old info and the new info
+        old_info_dict = _get_non_none_dict(old_info)
+        if completion.fixp.structured_output is None:
+            raise ValueError("No structured output found in completion")
+        new_info_dict = _get_non_none_dict(completion.fixp.structured_output)
+
+        # TODO(dbmikus) add a way to merge old and new fields when they are both
+        # set
+
+        # Only copy over fields not set on the new info
+        for k in old_info_dict.keys():
+            if new_info_dict.get(k, None) is None:
+                new_info_dict[k] = old_info_dict[k]
+
+        self.info = self.info_model(**new_info_dict)
+        self.info_history.append(self.info)
+        completion.fixp.structured_output = self.info
+        return completion
+
+    def format_questions(
+        self,
+        info: Optional[T] = None,
+    ) -> str:
+        """Format the questions for the missing fields.
+
+        Format the questions for the missing fields, which can be passed to a
+        human or to another agent.
+        """
+        if info is None:
+            info = self.info
+        missing = self.missing_fields()
+
+        # get the questions for the missing fields
+        questions = "\n".join([f"- {self._questions[k]}" for k in missing.keys()])
+
+        return "We're still missing some info. Can you tell us:\n\n" f"{questions}"
+
+
+def _get_non_none_dict(info: BaseModel) -> Dict[str, Any]:
+    return {k: v for k, v in info.model_dump().items() if v is not None}

--- a/src/fixpoint_extras/services/formagent/tasks/__init__.py
+++ b/src/fixpoint_extras/services/formagent/tasks/__init__.py
@@ -1,9 +1,13 @@
 """The workflow steps"""
 
+from . import classify
+from . import invoice
 from .classify import classify_form_type, FormType
 from .invoice import answer_invoice_questions, InvoiceQuestions
 
 __all__ = [
+    "classify",
+    "invoice",
     "classify_form_type",
     "FormType",
     "answer_invoice_questions",


### PR DESCRIPTION
Add an InfoGatherer controller that can control an agent whose job it is to gather answers to a set of form fields.

There's a new concept here, of a "controller". A controller can be thought of a controller (duh) or a manager of other AI agents and the process for how they work together to accomplish something. It's a higher level way to compose and coordiante agents.

Later there could be some overlap of responsibility between "agents" and "controllers", but I think of the difference like this:

Agents are backed by some AI, and they can take multiple steps, but generally you just ask the agent to accomplish something and it does it.

Controllers can layer on top of a single agent, or can coordinate multiple agents, and expose interfaces designed to be controlled by our software systems or other AIs.

In general, controllers do not have a uniform interface between controllers.

It looks like this "AI controller" nomenclature is being explored in other places:

https://www.microsoft.com/en-us/research/blog/ai-controller-interface-generative-ai-with-a-lightweight-llm-integrated-vm/