### PR TITLE
Fix warnings instantiating ChatCompletion instance

### DIFF
--- a/src/fixpoint/completions/chat_completion.py
+++ b/src/fixpoint/completions/chat_completion.py
@@ -29,7 +29,7 @@ T = TypeVar("T", bound=BaseModel)
 Tinner = TypeVar("Tinner", bound=BaseModel)
 
 
-class ChatCompletion(Generic[T], OpenAIChatCompletion):
+class ChatCompletion(OpenAIChatCompletion, Generic[T]):
     """
     A class that wraps a completion with a Fixpoint completion.
     """
@@ -37,15 +37,12 @@ class ChatCompletion(Generic[T], OpenAIChatCompletion):
     _original_completion: OpenAIChatCompletion = PrivateAttr()
     fixp: "ChatCompletion.Fixp[T]" = Field(exclude=True)
 
-    class Fixp(Generic[Tinner]):
+    class Fixp(BaseModel, Generic[Tinner]):
         """
         A class that represents a Fixpoint completion.
         """
 
         structured_output: Optional[Tinner]
-
-        def __init__(self, structured_output: Optional[Any] = None) -> None:
-            self.structured_output = structured_output
 
     # pylint: disable=super-init-not-called
     def __init__(
@@ -75,7 +72,7 @@ class ChatCompletion(Generic[T], OpenAIChatCompletion):
             usage=usage,
         )
         _raw_set_attr(self, "_original_completion", orig_completion)
-        _raw_set_attr(self, "fixp", ChatCompletion.Fixp(structured_output))
+        self.fixp = ChatCompletion.Fixp(structured_output=structured_output)
 
     @classmethod
     def from_original_completion(

--- a/src/fixpoint_extras/services/formagent/controllers/infogather.py
+++ b/src/fixpoint_extras/services/formagent/controllers/infogather.py
@@ -122,7 +122,7 @@ class InfoGatherer(Generic[T]):
         new_info_dict = _get_non_none_dict(completion.fixp.structured_output)
 
         # TODO(dbmikus) add a way to merge old and new fields when they are both
-        # set
+        # set [PRO-15]
 
         # Only copy over fields not set on the new info
         for k in old_info_dict.keys():


### PR DESCRIPTION
We were getting this error when initing new `ChatCompletion` instances:

> GenericBeforeBaseModelWarning: Classes should inherit from `BaseModel`
> before generic classes (e.g. `typing.Generic[T]`) for pydantic
> generics to work properly.

I swapped the order of the parent classes that `ChatCompletion` inherits
from, and this caused other errors. I fixed this by making the
`ChatCompletion.Fixp` class also inherit `pydantic.BaseModel`.