### PR TITLE
A few dev UX improvements and code re-orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
 parts/
 sdist/
 var/

--- a/docs/src/lib/utils.ts
+++ b/docs/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/fixpoint/agents/callbacks/__init__.py
+++ b/src/fixpoint/agents/callbacks/__init__.py
@@ -1,0 +1,34 @@
+"""Pre- and post-inference callback functions."""
+
+from typing import List
+
+import tiktoken
+
+from fixpoint.logging import logger
+from fixpoint.completions import (
+    ChatCompletionMessageParam,
+)
+
+
+class TikTokenLogger:
+    """A completion callback class for logging the number of tokens in the messages"""
+
+    _tokenizer: tiktoken.Encoding
+
+    def __init__(self, model_name: str):
+        self._tokenizer = tiktoken.encoding_for_model(model_name)
+
+    def tiktoken_logger(
+        self, messages: List[ChatCompletionMessageParam]
+    ) -> List[ChatCompletionMessageParam]:
+        """Log the number of tokens in the messages"""
+
+        # TODO(dbmikus) I'm not sure if this is how OpenAI combines multiple
+        # message objects into a single string before tokenizing.
+        joined = "\n".join([f"{m['role']}: {m['content']}" for m in messages])
+        tokenized = self._tokenizer.encode(joined)
+
+        # TODO(dbmikus) replace with a logger
+        # logger.info(f"Total input tokens: {len(tokenized)}")
+        logger.info("Total input tokens: %s", len(tokenized))
+        return messages

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -13,10 +13,8 @@ from typing import (
 )
 
 from pydantic import BaseModel
-import tiktoken
 
-from ..logging import logger
-from ..completions import (
+from fixpoint.completions import (
     ChatCompletionMessageParam,
     ChatCompletion,
     ChatCompletionToolChoiceOptionParam,
@@ -111,27 +109,3 @@ PreCompletionFn = Callable[
 CompletionCallback = Callable[
     [List[ChatCompletionMessageParam], ChatCompletion[BaseModel]], None
 ]
-
-
-class TikTokenLogger:
-    """A completion callback class for logging the number of tokens in the messages"""
-
-    _tokenizer: tiktoken.Encoding
-
-    def __init__(self, model_name: str):
-        self._tokenizer = tiktoken.encoding_for_model(model_name)
-
-    def tiktoken_logger(
-        self, messages: List[ChatCompletionMessageParam]
-    ) -> List[ChatCompletionMessageParam]:
-        """Log the number of tokens in the messages"""
-
-        # TODO(dbmikus) I'm not sure if this is how OpenAI combines multiple
-        # message objects into a single string before tokenizing.
-        joined = "\n".join([f"{m['role']}: {m['content']}" for m in messages])
-        tokenized = self._tokenizer.encode(joined)
-
-        # TODO(dbmikus) replace with a logger
-        # logger.info(f"Total input tokens: {len(tokenized)}")
-        logger.info("Total input tokens: %s", len(tokenized))
-        return messages

--- a/src/fixpoint/analyze/memory.py
+++ b/src/fixpoint/analyze/memory.py
@@ -51,7 +51,7 @@ class DataframeMemory(Memory):
             "all_tool_call_args": [],
             "workflow_name": [],
         }
-        for idx, memitem in enumerate(self.memory()):
+        for idx, memitem in enumerate(self.memories()):
             messages = memitem.messages
             completion = memitem.completion
             workflow_run_id = memitem.workflow_run.id if memitem.workflow_run else None

--- a/src/fixpoint/memory/_memory.py
+++ b/src/fixpoint/memory/_memory.py
@@ -52,8 +52,8 @@ class MemoryItem:
 class SupportsMemory(Protocol):
     """A protocol for adding memory to an agent"""
 
-    def memory(self) -> List[MemoryItem]:
-        """Get the memory"""
+    def memories(self) -> List[MemoryItem]:
+        """Get the list of memories"""
 
     def store_memory(
         self,
@@ -96,8 +96,8 @@ class Memory(SupportsMemory):
         if self._storage is not None:
             self._storage.insert(mem_item)
 
-    def memory(self) -> List[MemoryItem]:
-        """Get the memory"""
+    def memories(self) -> List[MemoryItem]:
+        """Get the list of memories"""
         if self._storage is not None:
             return self._storage.fetch_latest()
         return self._memory
@@ -106,7 +106,7 @@ class Memory(SupportsMemory):
         """Return the formatted string of messages. Useful for printing/debugging"""
         delim = "============================================================"
         lines = []
-        for mem in self.memory():
+        for mem in self.memories():
             lines.extend(self._format_single_mem(mem))
             lines.append(delim)
         return "\n".join(lines)

--- a/src/fixpoint_extras/services/formagent/setup.py
+++ b/src/fixpoint_extras/services/formagent/setup.py
@@ -4,7 +4,7 @@ from typing import Mapping, Optional
 
 import fixpoint
 from fixpoint.cache import SupportsChatCompletionCache
-from fixpoint.agents.protocol import TikTokenLogger
+from fixpoint.agents.callbacks import TikTokenLogger
 from fixpoint.agents.openai import OpenAIClients
 from fixpoint.analyze.memory import DataframeMemory
 

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -18,7 +18,7 @@ class TestMockAgent:
             completion_fn=MockCompletionGenerator().new_mock_completion, memory=mem
         )
 
-        assert mem.memory() == []
+        assert mem.memories() == []
         cmpl = agent.create_completion(
             messages=[
                 messages.smsg("I am a system"),
@@ -26,7 +26,7 @@ class TestMockAgent:
             ]
         )
         assert cmpl.choices[0].message.content == "test 0"
-        mems = mem.memory()
+        mems = mem.memories()
         assert len(mems) == 1
         assert mems[0].messages == [
             messages.smsg("I am a system"),

--- a/tests/memory/test_memgpt.py
+++ b/tests/memory/test_memgpt.py
@@ -30,10 +30,10 @@ class TestMemGPTSummaryAgent:
         )
 
         # We are under the token limit, so we don't summarize.
-        assert len(mem.memory()) == 1
+        assert len(mem.memories()) == 1
         # We are under the token limit, so we did not summarize and product any
         # extra messages.
-        assert len(mem.memory()[0].messages) == 2
+        assert len(mem.memories()[0].messages) == 2
 
 
 def test_context_length_check() -> None:

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -11,14 +11,14 @@ from ..supabase_test_utils import test_inputs
 class TestWithMemory:
     def test_store_memory(self) -> None:
         memstore = Memory()
-        assert memstore.memory() == []
+        assert memstore.memories() == []
         msgs: List[ChatCompletionMessageParam] = [
             {"role": "system", "content": "hello!"}
         ]
         cmpl = new_mock_completion()
         memstore.store_memory(msgs, cmpl)
 
-        stored_memory = memstore.memory()
+        stored_memory = memstore.memories()
         expected_memory = [MemoryItem(messages=msgs, completion=cmpl)]
 
         assert len(stored_memory) == len(expected_memory) == 1
@@ -63,14 +63,14 @@ class TestWithMemoryWithStorage:
         )
 
         memstore = Memory(storage=storage)
-        assert memstore.memory() == []
+        assert memstore.memories() == []
         msgs: List[ChatCompletionMessageParam] = [
             {"role": "system", "content": "hello!"}
         ]
         cmpl = new_mock_completion()
         memstore.store_memory(msgs, cmpl)
 
-        stored_memory = memstore.memory()
+        stored_memory = memstore.memories()
         expected_memory = [MemoryItem(messages=msgs, completion=cmpl)]
 
         assert len(stored_memory) == len(expected_memory) == 1


### PR DESCRIPTION
Move agent pre- and post-callbacks to separate module.

Fix weird gitignore issue ignoring "lib/" folders.

Rename the `Memory.memory` function to `memories` because it makes it clearer that we are getting the list of all memories.