### PR TITLE
Fix Supabase tests

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -7,4 +7,21 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 cd $ROOT_DIR
 
+SUPABASE_URL=$(\
+    supabase status -o env | grep API_URL | sed 's/API_URL=//' \
+    | sed 's/"//g'
+)
+SUPABASE_KEY=$(\
+    supabase status -o env | grep SERVICE_ROLE_KEY | sed 's/SERVICE_ROLE_KEY=//' \
+    | sed 's/"//g'
+)
+POSTGRES_URL=$(\
+    supabase status -o env | grep DB_URL | sed 's/DB_URL=//' \
+    | sed 's/"//g'
+)
+
+export SUPABASE_URL=$SUPABASE_URL
+export SUPABASE_KEY=$SUPABASE_KEY
+export POSTGRES_URL=$POSTGRES_URL
+
 poetry run pytest

--- a/db/migrations/20240519224547_initial-tables.sql
+++ b/db/migrations/20240519224547_initial-tables.sql
@@ -1,4 +1,6 @@
 -- migrate:up
+CREATE SCHEMA fixpoint;
+
 CREATE TABLE fixpoint.workflows(
   id text PRIMARY KEY,
   name TEXT NOT NULL,
@@ -8,21 +10,21 @@ CREATE TABLE fixpoint.workflows(
 );
 
 CREATE TABLE fixpoint.chat_completion_inputs(
-  id UUID PRIMARY KEY,
-  workflow_id UUID REFERENCES fixpoint.workflows(id),
-  session_id UUID NULL,
+  id text PRIMARY KEY,
+  workflow_id text REFERENCES fixpoint.workflows(id),
+  session_id text NULL,
   provider TEXT NOT NULL,
   model TEXT NOT NULL,
   request JSONB NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT NOW(),    
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE fixpoint.chat_completion_outputs(
-  id UUID PRIMARY KEY,
-  input_id UUID REFERENCES fixpoint.chat_completion_inputs(id),
-  workflow_id UUID REFERENCES fixpoint.workflows(id),
-  session_id UUID NULL,
+  id text PRIMARY KEY,
+  input_id text REFERENCES fixpoint.chat_completion_inputs(id),
+  workflow_id text REFERENCES fixpoint.workflows(id),
+  session_id text NULL,
   response JSONB NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW()
@@ -59,3 +61,5 @@ DROP FUNCTION fixpoint.update_updated_at_column;
 DROP TABLE fixpoint.chat_completion_outputs;
 DROP TABLE fixpoint.chat_completion_inputs;
 DROP TABLE fixpoint.workflows;
+
+DROP SCHEMA fixpoint;

--- a/src/fixpoint/cache/tlru.py
+++ b/src/fixpoint/cache/tlru.py
@@ -19,10 +19,10 @@ from .protocol import (
     SupportsTTLCacheItem,
     SupportsChatCompletionCache,
 )
-from ..storage.protocol import SupportsStorage
+from ..storage.protocol import SupportsStorage, SupportsSerialization
 
 
-class TLRUCacheItem(SupportsTTLCacheItem[V]):
+class TLRUCacheItem(SupportsTTLCacheItem[V], SupportsSerialization["TLRUCacheItem[V]"]):
     """
     TLRU Cache Item
     """

--- a/src/fixpoint/storage/protocol.py
+++ b/src/fixpoint/storage/protocol.py
@@ -59,7 +59,7 @@ V_co = TypeVar("V_co", covariant=True)  # Value type
 
 
 @runtime_checkable
-class SupportsSupabaseSerialization(Protocol[V_co]):
+class SupportsSerialization(Protocol[V_co]):
     """Protocol for Supabase storage serialization"""
 
     def serialize(self) -> dict[str, Any]:

--- a/src/fixpoint/storage/supabase.py
+++ b/src/fixpoint/storage/supabase.py
@@ -4,9 +4,9 @@ from typing import Any, Optional, TypeVar, List, Type, Union, cast, Dict
 from pydantic import BaseModel
 from postgrest import SyncRequestBuilder  # type: ignore
 from supabase import create_client, Client
-from .protocol import SupportsStorage, SupportsSupabaseSerialization
+from .protocol import SupportsStorage, SupportsSerialization
 
-V = TypeVar("V", bound=Union[BaseModel, SupportsSupabaseSerialization[Any]])
+V = TypeVar("V", bound=Union[BaseModel, SupportsSerialization[Any]])
 
 
 class SupabaseStorage(SupportsStorage[V]):
@@ -68,7 +68,7 @@ class SupabaseStorage(SupportsStorage[V]):
         ):
             return cast(V, self._value_type(**data))
         elif isinstance(self._value_type, type) and issubclass(
-            self._value_type, SupportsSupabaseSerialization
+            self._value_type, SupportsSerialization
         ):
             return cast(V, self._value_type.deserialize(data=data))
         else:

--- a/tests/cache/tlru_test.py
+++ b/tests/cache/tlru_test.py
@@ -4,7 +4,7 @@ import pytest
 from freezegun import freeze_time
 from fixpoint.cache.tlru import TLRUCache, TLRUCacheItem
 from fixpoint.storage.supabase import SupabaseStorage
-from ..supabase_test_utils import test_inputs
+from ..supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
 
 class TestTLRUCache:
@@ -34,13 +34,16 @@ class TestTLRUCache:
             assert ttlCache.get("test") is None  # evicted
 
 
-@pytest.mark.skip(reason="Disabled until we have a supabase instance running in CI")
+@pytest.mark.skipif(
+    not is_supabase_enabled(),
+    reason="Disabled until we have a supabase instance running in CI",
+)
 @freeze_time("2023-01-01 00:00:00")
 class TestTLRUCacheWithStorage:
 
     @freeze_time("2023-01-01 00:00:00")
     @pytest.mark.parametrize(
-        "test_inputs",
+        "supabase_setup_url_and_key",
         [
             (
                 f"""
@@ -58,8 +61,10 @@ class TestTLRUCacheWithStorage:
         ],
         indirect=True,
     )
-    def test_tlru_cache_with_storage(self, test_inputs: Tuple[str, str]) -> None:
-        url, key = test_inputs
+    def test_tlru_cache_with_storage(
+        self, supabase_setup_url_and_key: Tuple[str, str]
+    ) -> None:
+        url, key = supabase_setup_url_and_key
 
         class MockChatCompletion:
             request: list[dict[str, str]]

--- a/tests/cache/tlru_test.py
+++ b/tests/cache/tlru_test.py
@@ -88,7 +88,11 @@ class TestTLRUCacheWithStorage:
             table="completion_cache",
             order_key="expires_at",
             id_column="key",
-            value_type=TLRUCacheItem[str],
+            # We cannot not specify the generic type parameter for
+            # TLRUCacheItem, because then when we try to do `isinstance(cls,
+            # type)`, the class will actually be a `typing.GenericAlias` and not
+            # a type (class definition).
+            value_type=TLRUCacheItem,
         )
 
         cache = TLRUCache[list[dict[str, str]], str](

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -5,7 +5,7 @@ from fixpoint.completions import ChatCompletionMessageParam
 from fixpoint.memory import Memory, MemoryItem
 from fixpoint.agents.mock import new_mock_completion
 from fixpoint.storage.supabase import SupabaseStorage
-from ..supabase_test_utils import test_inputs
+from ..supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
 
 class TestWithMemory:
@@ -30,29 +30,35 @@ class TestWithMemory:
         assert first_stored_memory.workflow_run == first_expected_memory.workflow_run
 
 
-@pytest.mark.skip(reason="Disabled until we have a supabase instance running in CI")
+@pytest.mark.skipif(
+    not is_supabase_enabled(),
+    reason="Disabled until we have a supabase instance running in CI",
+)
 class TestWithMemoryWithStorage:
 
     @pytest.mark.parametrize(
-        "test_inputs",
+        "supabase_setup_url_and_key",
         [
             (
                 f"""
         CREATE TABLE IF NOT EXISTS public.memory_store (
             messages jsonb PRIMARY KEY,
             completion jsonb,
-            workflow jsonb
+            workflow jsonb,
+            workflow_run jsonb
         );
 
-        TRUNCATE TABLE public.memory_store
+        TRUNCATE TABLE public.memory_store;
         """,
                 "public.memory_store",
             )
         ],
         indirect=True,
     )
-    def test_store_memory_with_storage(self, test_inputs: Tuple[str, str]) -> None:
-        url, key = test_inputs
+    def test_store_memory_with_storage(
+        self, supabase_setup_url_and_key: Tuple[str, str]
+    ) -> None:
+        url, key = supabase_setup_url_and_key
         storage = SupabaseStorage(
             url,
             key,

--- a/tests/storage/supabase_test.py
+++ b/tests/storage/supabase_test.py
@@ -2,14 +2,17 @@ from typing import Tuple, Any
 import pytest
 from pydantic import BaseModel
 from fixpoint.storage import SupabaseStorage
-from ..supabase_test_utils import test_inputs
+from ..supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
 
-@pytest.mark.skip(reason="Disabled until we have a supabase instance running in CI")
+@pytest.mark.skipif(
+    not is_supabase_enabled(),
+    reason="Disabled until we have a supabase instance running in CI",
+)
 class TestSupabaseStorage:
 
     @pytest.mark.parametrize(
-        "test_inputs",
+        "supabase_setup_url_and_key",
         [
             (
                 f"""
@@ -26,8 +29,10 @@ class TestSupabaseStorage:
         ],
         indirect=True,
     )
-    def test_client_instantiation(self, test_inputs: Tuple[str, str]) -> None:
-        url, key = test_inputs
+    def test_client_instantiation(
+        self, supabase_setup_url_and_key: Tuple[str, str]
+    ) -> None:
+        url, key = supabase_setup_url_and_key
 
         class Person(BaseModel):
             id: int

--- a/tests/workflows/imperative/test_forms.py
+++ b/tests/workflows/imperative/test_forms.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from fixpoint.storage.supabase import SupabaseStorage
 from fixpoint_extras.workflows.imperative.workflow import Workflow
 from fixpoint_extras.workflows.imperative.form import Form
-from ...supabase_test_utils import test_inputs
+from ...supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
 
 class Foo(BaseModel):
@@ -66,9 +66,12 @@ class TestForms:
         assert listed_forms[0].path == "/foo"
         assert listed_forms[0].metadata == {"mymeta": "data is here!"}
 
-    @pytest.mark.skip(reason="Disabled until we have a supabase instance running in CI")
+    @pytest.mark.skipif(
+        not is_supabase_enabled(),
+        reason="Disabled until we have a supabase instance running in CI",
+    )
     @pytest.mark.parametrize(
-        "test_inputs",
+        "supabase_setup_url_and_key",
         [
             (
                 f"""
@@ -91,8 +94,10 @@ class TestForms:
         ],
         indirect=True,
     )
-    def test_workflow_forms_with_storage(self, test_inputs: Tuple[str, str]) -> None:
-        url, key = test_inputs
+    def test_workflow_forms_with_storage(
+        self, supabase_setup_url_and_key: Tuple[str, str]
+    ) -> None:
+        url, key = supabase_setup_url_and_key
 
         form_storage = SupabaseStorage(
             url,


### PR DESCRIPTION
Fix TLRUCache and Supabase test failure

The tests for the TLRUCache with Supabase storage failed because the
TLRUCacheItem did not implement `SupportsSerialization`. Fix this.

Supabase and database testing

Make some improvements to how our tests integrate with Supabase.

`bin/test` parses out the Supabase environment variables when running
test.

Fix the `db/migrations` files so that they run.

Rename the Pytest fixture `test_inputs` to `supabase_setup_url_and_key`
so that it is easier to understand what the fixture is doing.

Conditionally run all Supabase tests if the necessary environment
variables are defined.