### PR TITLE
Improve workflow form serialization and updates

### DIFF
--- a/src/fixpoint/storage/supabase.py
+++ b/src/fixpoint/storage/supabase.py
@@ -124,22 +124,22 @@ class SupabaseStorage(SupportsStorage[V]):
         return None
 
     def _get_serialized_data(self, data: V) -> dict[str, Any]:
-        if isinstance(data, BaseModel):
-            return data.model_dump()
-        elif hasattr(data, "serialize"):
+        if hasattr(data, "serialize"):
             return data.serialize()
+        elif isinstance(data, BaseModel):
+            return data.model_dump()
         else:
             raise TypeError("Unsupported data type for serialization")
 
     def _get_deserialized_data(self, data: Dict[str, Any]) -> V:
         if isinstance(self._value_type, type) and issubclass(
-            self._value_type, BaseModel
-        ):
-            return cast(V, self._value_type(**data))
-        elif isinstance(self._value_type, type) and issubclass(
             self._value_type, SupportsSerialization
         ):
             return cast(V, self._value_type.deserialize(data=data))
+        elif isinstance(self._value_type, type) and issubclass(
+            self._value_type, BaseModel
+        ):
+            return cast(V, self._value_type(**data))
         else:
             raise TypeError(
                 f"The type {self._value_type} does not support deserialization"

--- a/src/fixpoint_extras/services/formagent/controllers/infogather.py
+++ b/src/fixpoint_extras/services/formagent/controllers/infogather.py
@@ -130,7 +130,7 @@ class InfoGatherer(Generic[T]):
             if new_info_dict.get(k, None) is None:
                 new_info_dict[k] = old_info_dict[k]
 
-        self.form.set_contents(new_info_dict)
+        self.form.update_contents(new_info_dict)
         self.info_history.append(self.form.contents)
         completion.fixp.structured_output = self.form.contents
         return completion

--- a/src/fixpoint_extras/workflows/imperative/form.py
+++ b/src/fixpoint_extras/workflows/imperative/form.py
@@ -1,11 +1,30 @@
 """A form is a set of fields for a user or agent to fill in."""
 
-import importlib
-from typing import Dict, Any, List, Type, TypeVar, Generic, Union, cast
+import json
+from typing import (
+    Dict,
+    Any,
+    List,
+    Type,
+    TypeVar,
+    Generic,
+    Union,
+    Optional,
+    get_origin,
+    get_args,
+)
 
-from pydantic import BaseModel, PrivateAttr, Field, computed_field, field_validator
+from pydantic import (
+    BaseModel,
+    PrivateAttr,
+    Field,
+    computed_field,
+    create_model,
+    field_validator,
+)
 
 from .version import Version
+
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -26,14 +45,6 @@ class Form(BaseModel, Generic[T]):
 
     workflow_run_id: str = Field(description="The workflow run id")
 
-    # Manually override model_dump_json
-    def model_dump(self, *_: Any, **__: Any) -> dict[str, Any]:
-        data = super().model_dump()
-        data["form_schema"] = (
-            f"{self.form_schema.__module__}.{self.form_schema.__name__}"
-        )
-        return data
-
     @computed_field  # type: ignore[misc]
     @property
     def task(self) -> str:
@@ -52,18 +63,6 @@ class Form(BaseModel, Generic[T]):
             return "__start__"
         return parts[2]
 
-    # This is the actual form schema and contents
-    @field_validator("form_schema", mode="before")
-    @classmethod
-    def convert_string_to_class(cls, v: str) -> Type[T]:
-        """Convert a string to a class"""
-        if isinstance(v, str):
-            module_name, class_name = v.rsplit(".", 1)
-            module = importlib.import_module(module_name)
-            v = getattr(module, class_name)
-            return cast(Type[T], v)
-        return v
-
     # We can't name it "schema" because that conflicts with a Pydantic method
     form_schema: Type[T] = Field(description="The form schema")
 
@@ -75,18 +74,29 @@ class Form(BaseModel, Generic[T]):
         """The (partially or fully) filled in form contents"""
         return self._contents
 
-    def set_contents(self, contents: Union[T, Dict[str, Any]]) -> None:
-        """Set the filled in form contents"""
+    def update_contents(self, contents: Union[T, Dict[str, Any]]) -> None:
+        """Update the filled in form contents
+
+        We preserve old fields, only setting in the values that are passed in.
+        """
         if isinstance(contents, dict):
-            self._contents = self.form_schema(**contents)
-        else:
-            self._contents = contents
+            allowed_fields = set(self.form_schema.model_fields.keys())
+            for key in contents.keys():
+                if key not in allowed_fields:
+                    raise ValueError(f'Form field "{key}" is not allowed')
+
+        if not isinstance(contents, BaseModel):
+            # Validate the contents according to the schema. Only necessary if
+            # we got a dict.
+            contents = self.form_schema(**contents)
+
+        contents_dict = contents.model_dump(include=contents.model_fields_set)
+        new_contents = self.contents.model_copy(update=contents_dict)
+        self._contents = new_contents
 
     @field_validator("form_schema")
     @classmethod
     def _validate_form_schema(cls, form_schema: Type[T]) -> Type[T]:
-        # TODO(dbmikus) test this
-
         # check that every field in the form_schema is optional. These are Pydantic fields
         for name, field in form_schema.model_fields.items():
             if field.get_default() is not None:
@@ -98,7 +108,7 @@ class Form(BaseModel, Generic[T]):
         # make sure that each form field is not a nested type like a list,
         # dictionary, object, or other complex types
         for name, field in form_schema.model_fields.items():
-            if isinstance(field.annotation, (list, dict, BaseModel, tuple, set)):
+            if not _is_valid_field_annotation(field.annotation):
                 raise ValueError(
                     f'Form field "{name}" must be a primitive type, '
                     "not a complex type like list, dict, object, tuple, or set, "
@@ -107,6 +117,127 @@ class Form(BaseModel, Generic[T]):
 
         return form_schema
 
+    @classmethod
+    def _create_pydantic_model_from_json_schema(
+        cls, schema: Dict[str, Any]
+    ) -> Type[BaseModel]:
+        """
+        Dynamically creates a Pydantic model from a JSON schema.
+
+        Args:
+        - schema (Dict[str, Any]): The JSON schema dictionary.
+        - model_name (str): The name of the model to create.
+
+        Returns:
+        - Type[BaseModel]: A dynamically created Pydantic model.
+        """
+        fields: Dict[str, Any] = {}
+
+        model_name = schema.get("title", "UnnamedModel")
+        if not isinstance(model_name, str):
+            raise ValueError("Form JSON schema has no title")
+        properties = schema.get("properties", {})
+        if not properties:
+            raise ValueError("Form JSON schema has no properties")
+
+        for field_name, details in properties.items():
+            if "anyOf" not in details:
+                raise ValueError("Form JSON schema is invalid")
+            type_strings = [option["type"] for option in details["anyOf"]]
+            if "null" not in type_strings:
+                raise ValueError(
+                    f"Form JSON schema: field {field_name} must be optional"
+                )
+            field_types: List[Type[Any]] = [
+                cls._json_schema_type_to_py_type(t)
+                for t in type_strings
+                # remove null types because we process them below
+                if t != "null"
+            ]
+
+            if len(field_types) == 0:
+                raise ValueError(
+                    f"Form JSON schema: field {field_name} must have at least one type"
+                )
+            pytype: Any
+            if len(field_types) == 1:
+                pytype = Optional[field_types[0]]
+            else:
+                pytype = Optional[Union[*field_types]]
+
+            field_description = details.get("description", None)
+            field_default = details.get("default", None)
+            field = Field(default=field_default, description=field_description)
+
+            # Add more complex type handling here as needed
+            fields[field_name] = (pytype, field)
+
+        return create_model(model_name, **fields)
+
+    @classmethod
+    def _json_schema_type_to_py_type(cls, t: str) -> Type[Any]:
+        if t == "string":
+            return str
+        elif t == "integer":
+            return int
+        elif t == "number":
+            return float
+        elif t == "boolean":
+            return bool
+        raise ValueError(f'Form field type "{t}" is not supported')
+
+    def serialize(self) -> Dict[str, Any]:
+        """Serialize the form to a string"""
+        m = self.model_dump()
+        del m["form_schema"]
+        m["form_schema"] = self.form_schema.model_json_schema()
+        m["contents"] = self.contents.model_dump()
+        return m
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> "Form[BaseModel]":
+        """Deserialize the form from a string"""
+        form_schema = data.pop("form_schema")
+        if isinstance(form_schema, str):
+            form_schema = json.loads(form_schema)
+        contents = data.pop("contents")
+        newdata = dict(data)
+        newdata["form_schema"] = cls._create_pydantic_model_from_json_schema(
+            form_schema
+        )
+        # If we do `form = cls(**newdata)`, Pydantic has errors like:
+        # E    form_schema
+        # E    Input should be a subclass of TicketOrderForm ...
+        #
+        # Because we dynamically deseriailize the JSON schema into a dynamically
+        # create Pydantic model, we won't actually subclass the originally
+        # defined form schema model.
+        form = Form[BaseModel](**newdata)
+        form.update_contents(contents)
+        return form
+
     def model_post_init(self, _context: Any) -> None:
         """Run Pydantic model post init code"""
         self._contents = self.form_schema()
+
+
+def _is_valid_field_annotation(annotation: Union[type, object, None]) -> bool:
+    if annotation is None:
+        return False
+
+    typeorigin = get_origin(annotation)
+    # typing.Optional becomes typing.Union[..., None]
+    if typeorigin != Union:
+        return False
+    typeargs = get_args(annotation)
+    if len(typeargs) < 2:
+        return False
+    found_nonetype = False
+    for t in typeargs:
+        if t is type(None):
+            found_nonetype = True
+        else:
+            if t not in (int, str, float, bool):
+                return False
+
+    return found_nonetype

--- a/src/fixpoint_extras/workflows/imperative/workflow.py
+++ b/src/fixpoint_extras/workflows/imperative/workflow.py
@@ -265,8 +265,7 @@ class _Forms:
         form = None
         if self._storage:
             # Form id is the primary identifier for a form, so specifying more fields is unecessary
-            form_with_meta = self._storage.fetch(resource_id=form_id)
-            form = Form(**form_with_meta.model_dump()) if form_with_meta else None
+            form = self._storage.fetch(resource_id=form_id)
         else:
             # If we are not using a storage backend, we assume that the form is in memory
             form = self._memory.get(form_id, None)
@@ -324,7 +323,7 @@ class _Forms:
             form = self.get(form_id=form_id)
             if not form:
                 raise ValueError(f"Form {form_id} not found")
-            form.set_contents(contents)
+            form.update_contents(contents)
             if metadata:
                 form.metadata = metadata
 
@@ -332,21 +331,7 @@ class _Forms:
             form = self._memory[form_id]
             if metadata is not None:
                 form.metadata = metadata
-            old_contents = form.contents.model_copy()
-
-            # merge the new contents with the old contents, and then explicilty
-            # validate it because passing in an `update` parameter to
-            # `model_copy` does not validate the values.
-
-            # TODO(dbmikus) make sure that model_copy works.
-            # TODO(dbmikus) differentiate between default `None` and explicit `None`
-            if isinstance(contents, BaseModel):
-                new_contents = old_contents.model_copy(update=contents.model_dump())
-            else:
-                new_contents = old_contents.model_copy(update=contents)
-            # TODO(dbmikus) make sure this validation works
-            new_contents.model_validate(new_contents)
-            form.set_contents(new_contents)
+            form.update_contents(contents)
 
         if self._storage:
             self._storage.update(form)

--- a/tests/workflows/imperative/test_forms.py
+++ b/tests/workflows/imperative/test_forms.py
@@ -1,70 +1,204 @@
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
+import json
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
 from fixpoint.storage.supabase import SupabaseStorage
 from fixpoint_extras.workflows.imperative.workflow import Workflow
-from fixpoint_extras.workflows.imperative.form import Form
+from fixpoint_extras.workflows.imperative.form import Form, _is_valid_field_annotation
+
 from ...supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
 
-class Foo(BaseModel):
-    foo: Optional[str] = None
-    bar: Optional[int] = None
+class TicketOrderForm(BaseModel):
+    name: Optional[str] = Field(
+        default=None, description="The name of the ticketholder"
+    )
+    age: Optional[int] = Field(default=None, description="The age of the ticketholder")
+    ticket_cost: Optional[float] = None
+    email: Optional[str] = Field(
+        default=None, description="The email of the ticketholder"
+    )
 
 
 class TestForms:
+    def test_validate_form_schema(self) -> None:
+        class WithoutOptional(BaseModel):
+            name: str
+            age: Optional[int] = None
+
+        with pytest.raises(Exception):
+            Form[WithoutOptional](
+                id="myform",
+                workflow_run_id="myworkflowrun",
+                form_schema=WithoutOptional,
+            )
+
+        class WithInvalidComplex(BaseModel):
+            names: Optional[List[str]] = None
+            age: Optional[int] = None
+
+        with pytest.raises(Exception):
+            Form[WithInvalidComplex](
+                id="myform",
+                workflow_run_id="myworkflowrun",
+                form_schema=WithInvalidComplex,
+            )
+
+        class WithValid(BaseModel):
+            name: Optional[str] = None
+            age: Optional[int] = None
+
+        class WithValidField(BaseModel):
+            name: Optional[str] = Field(default=None)
+            age: Optional[int] = Field(default=None)
+
+        for form_schema_cls in (WithValid, WithValidField):
+            form = Form[BaseModel](
+                id="myform",
+                workflow_run_id="myworkflowrun",
+                form_schema=form_schema_cls,
+            )
+            assert form.id == "myform"
+            assert form.workflow_run_id == "myworkflowrun"
+            assert form.form_schema == form_schema_cls
+
+    def test_form_serialization(self) -> None:
+        form = Form[TicketOrderForm](
+            id="myform",
+            workflow_run_id="myworkflowrun",
+            path="/task/step",
+            form_schema=TicketOrderForm,
+            metadata={"organization": "fixpoint.co"},
+        )
+        form.update_contents(TicketOrderForm(name="Dylan", age=32))
+        serialized = form.serialize()
+
+        # It can be serialized to text/json
+        json_serialized = json.dumps(serialized)
+        serialized = json.loads(json_serialized)
+
+        # deseriailization doesn't actually have access to the underlying Form
+        # schema class because we dynamically create a new Pydantic model when
+        # deserializing.
+        des_form: Form[BaseModel] = Form.deserialize(serialized)
+        # But you can cast the type if you want and if you know what your form's type is!
+        new_form = cast(Form[TicketOrderForm], des_form)
+
+        assert new_form.id == "myform"
+        assert new_form.id == form.id
+
+        assert new_form.workflow_run_id == "myworkflowrun"
+        assert new_form.workflow_run_id == form.workflow_run_id
+
+        assert new_form.path == "/task/step"
+        assert new_form.path == form.path
+
+        assert new_form.metadata == {"organization": "fixpoint.co"}
+        assert new_form.metadata == form.metadata
+
+        # We can't compare the contents directly, because when we deserialized
+        # the saved form, we dynamically created a new Pydantic model class,
+        # which is different than the prior Pydantic model class.
+        assert form.contents.model_dump() == new_form.contents.model_dump()
+        assert new_form.contents.model_dump() == {
+            "name": "Dylan",
+            "age": 32,
+            "email": None,
+            "ticket_cost": None,
+        }
+
+        # Because we properly serialized and deserialized the form schema, it
+        # should complain when we try to set a field incorrectly.
+        with pytest.raises(Exception):
+            new_form.update_contents({"bad": "contents"})
+
+        with pytest.raises(Exception):
+            new_form.update_contents({"age": "I am older than time itself"})
+
+        new_form.update_contents({"age": 100})
+        assert new_form.contents.age == 100
+
+    def test_form_serialization_no_contents(self) -> None:
+        pytest.skip("skip it")
+        form = Form[TicketOrderForm](
+            id="myform",
+            workflow_run_id="myworkflowrun",
+            path="/task/step",
+            form_schema=TicketOrderForm,
+        )
+        serialized = form.serialize()
+        assert serialized["contents"] == {"age": None, "email": None, "name": None}
+        new_form: Form[TicketOrderForm] = Form.deserialize(serialized)
+        assert new_form.contents == TicketOrderForm()
+
+    def test_form_update_contents_dict(self) -> None:
+        self.assert_form_update_contents(use_model=False)
+
+    def test_form_update_contents_model(self) -> None:
+        self.assert_form_update_contents(use_model=True)
+
+    def assert_form_update_contents(self, use_model: bool) -> None:
+
+        if use_model:
+
+            def contents_converter(
+                contents: Dict[str, Any]
+            ) -> Union[TicketOrderForm, Dict[str, Any]]:
+                return TicketOrderForm(**contents)
+
+        else:
+
+            def contents_converter(
+                contents: Dict[str, Any]
+            ) -> Union[TicketOrderForm, Dict[str, Any]]:
+                return contents
+
+        form = Form[TicketOrderForm](
+            id="myform",
+            workflow_run_id="myworkflowrun",
+            path="/task/step",
+            form_schema=TicketOrderForm,
+        )
+        assert form.contents == TicketOrderForm()
+
+        # only do this if we are parsing the contents as a dict, because if
+        # contents_converter converts to a Pydantic model it will strip out the
+        # bad contents according to `model_config['extra']`
+        if not use_model:
+            with pytest.raises(Exception):
+                form.update_contents(contents_converter({"bad": "contents"}))
+
+        assert form.contents == TicketOrderForm()
+
+        form.update_contents(contents_converter({"name": "Dylan", "age": 32}))
+        assert form.contents == TicketOrderForm(name="Dylan", age=32)
+
+        with pytest.raises(Exception):
+            form.update_contents(contents_converter({"age": "My age is 9000"}))
+        assert form.contents == TicketOrderForm(name="Dylan", age=32)
+
+        form.update_contents(contents_converter({"email": "hello@fixpoint.co"}))
+        assert form.contents == TicketOrderForm(
+            name="Dylan", age=32, email="hello@fixpoint.co"
+        )
+
+        form.update_contents(contents_converter({"name": "Jakub"}))
+        assert form.contents == TicketOrderForm(
+            name="Jakub", age=32, email="hello@fixpoint.co"
+        )
+
+        form.update_contents(contents_converter({"name": None}))
+        assert form.contents == TicketOrderForm(
+            name=None, age=32, email="hello@fixpoint.co"
+        )
 
     def test_workflow_forms(self) -> None:
         workflow = Workflow(
             id="test_workflow",
         )
         assert workflow.id == "test_workflow"
-
-        run = workflow.run()
-        assert run.id is not None
-
-        class Foo(BaseModel):
-            foo: Optional[str] = None
-            bar: Optional[int] = None
-
-        # Store the form on the run
-        stored_form = run.forms.store(
-            form_id="foo",
-            schema=Foo,
-            path="/foo",
-            metadata={"foo": "bar"},
-        )
-        assert isinstance(stored_form, Form)
-        assert stored_form.id == "foo"
-        assert stored_form.path == "/foo"
-        assert stored_form.metadata == {"foo": "bar"}
-
-        # Retrieved form from run with id
-        retrieved_form = run.forms.get(form_id="foo")
-        assert isinstance(retrieved_form, Form)
-        assert retrieved_form.id == "foo"
-        assert retrieved_form.path == "/foo"
-        assert retrieved_form.metadata == {"foo": "bar"}
-
-        # Updated form
-        updated_form: Form[Foo] = run.forms.update(
-            form_id="foo", contents={"foo": "zar"}, metadata={"mymeta": "data is here!"}
-        )
-        assert isinstance(updated_form, Form)
-        assert updated_form.id == "foo"
-        # path is not updated
-        assert updated_form.path == "/foo"
-        assert updated_form.contents.model_dump() == {"foo": "zar", "bar": None}
-        assert updated_form.metadata == {"mymeta": "data is here!"}
-
-        # List forms
-        listed_forms = run.forms.list()
-        assert isinstance(listed_forms, List)
-        assert len(listed_forms) == 1
-        assert isinstance(listed_forms[0], Form)
-        assert listed_forms[0].id == "foo"
-        assert listed_forms[0].path == "/foo"
-        assert listed_forms[0].metadata == {"mymeta": "data is here!"}
+        self.assert_workflow_forms_works(workflow)
 
     @pytest.mark.skipif(
         not is_supabase_enabled(),
@@ -105,13 +239,16 @@ class TestForms:
             table="forms_with_metadata",
             order_key="id",
             id_column="id",
-            value_type=Form[Foo],
+            value_type=Form[TicketOrderForm],
         )
 
         workflow = Workflow(
             id="test_workflow",
             form_storage=form_storage,
         )
+        self.assert_workflow_forms_works(workflow)
+
+    def assert_workflow_forms_works(self, workflow: Workflow) -> None:
         assert workflow.id == "test_workflow"
 
         run = workflow.run()
@@ -120,7 +257,7 @@ class TestForms:
         # Store the form on the run
         stored_form = run.forms.store(
             form_id="foo",
-            schema=Foo,
+            schema=TicketOrderForm,
             path="/foo",
             metadata={"foo": "bar"},
         )
@@ -136,16 +273,38 @@ class TestForms:
         assert retrieved_form.path == "/foo"
         assert retrieved_form.metadata == {"foo": "bar"}
 
+        # Updating form with invalid contents should fail
+        with pytest.raises(Exception):
+            run.forms.update(form_id="foo", contents={"bad": "contents"})
+
         # Updated form
-        updated_form: Form[Foo] = run.forms.update(
-            form_id="foo", contents={"foo": "zar"}, metadata={"mymeta": "data is here!"}
+        updated_form: Form[TicketOrderForm] = run.forms.update(
+            form_id="foo",
+            contents={"name": "Dylan"},
+            metadata={"mymeta": "data is here!"},
         )
         assert isinstance(updated_form, Form)
         assert updated_form.id == "foo"
         # path is not updated
         assert updated_form.path == "/foo"
-        assert updated_form.contents.model_dump() == {"foo": "zar", "bar": None}
+        assert updated_form.contents.model_dump() == {
+            "name": "Dylan",
+            "age": None,
+            "email": None,
+            "ticket_cost": None,
+        }
         assert updated_form.metadata == {"mymeta": "data is here!"}
+
+        # Updating the form contents preserves old contents, merging in the update
+        updated_form = run.forms.update(
+            form_id="foo", contents={"email": "hello@fixpoint.co"}
+        )
+        assert updated_form.contents.model_dump() == {
+            "name": "Dylan",
+            "age": None,
+            "email": "hello@fixpoint.co",
+            "ticket_cost": None,
+        }
 
         # List forms
         listed_forms = run.forms.list()
@@ -156,3 +315,22 @@ class TestForms:
         assert listed_forms[0].id == "foo"
         assert listed_forms[0].path == "/foo"
         assert listed_forms[0].metadata == {"mymeta": "data is here!"}
+
+
+class TestFormTypeHelpers:
+    def test_is_valid_field_annotation(self) -> None:
+        assert not _is_valid_field_annotation(None)
+        assert not _is_valid_field_annotation(int)
+        assert not _is_valid_field_annotation(Union[int, str])
+        assert not _is_valid_field_annotation(Optional[list])
+        assert not _is_valid_field_annotation(Optional[dict])
+        assert not _is_valid_field_annotation(Union[dict, int, None])
+
+        assert _is_valid_field_annotation(Optional[int])
+        assert _is_valid_field_annotation(Optional[float])
+        assert _is_valid_field_annotation(Optional[str])
+        assert _is_valid_field_annotation(Optional[bool])
+        assert _is_valid_field_annotation(Union[int, None])
+        assert _is_valid_field_annotation(Union[int, str, None])
+        assert _is_valid_field_annotation(Optional[Union[int, bool, None]])
+        assert _is_valid_field_annotation(Optional[Union[int, bool, str, float]])


### PR DESCRIPTION
Make the Workflow Form serialization/deserialization logic use the underlying JSON schema. This is more durable for long-term storage than relying on import paths of Pydantic models, and theoretically it lets us support non-Python languages in the future.

As part of this, we limit the types of forms that users can create so that it is easy to do form deserialization. We force the form to:

1. only support simple non-nested fields: bool, str, int, float
2. each field must be optional, since the form starts empty and we fill it in

We also update the logic for how a form is updated. When you call `form.update`, it only updates the fields you specify, leaving the other ones as is.

Finally, make a little change in how Supabase storage does form serialization and deserialization. We used to prefer to serialize by calling Pydantic's `BaseModel.model_dump`, but now we prefer to use `serialize`/`deserialize` if they exist, because we have more control over them.