### PR TITLE
Make chat completion caching support more chat completion parameters

### DIFF
--- a/src/fixpoint/agents/oai/openai.py
+++ b/src/fixpoint/agents/oai/openai.py
@@ -117,6 +117,7 @@ class OpenAI:
             model: Optional[str] = None,
             tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
             tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+            temperature: Optional[float] = None,
             workflow_run: Optional[SupportsWorkflowRun] = None,
             **kwargs: Any,
         ) -> ChatCompletion[BaseModel]: ...
@@ -130,6 +131,7 @@ class OpenAI:
             model: Optional[str] = None,
             tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
             tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+            temperature: Optional[float] = None,
             workflow_run: Optional[SupportsWorkflowRun] = None,
             **kwargs: Any,
         ) -> ChatCompletion[T_contra]: ...
@@ -140,6 +142,7 @@ class OpenAI:
             *,
             response_model: Optional[Type[T_contra]] = None,
             model: Optional[str] = None,
+            temperature: Optional[float] = None,
             tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
             tools: Optional[Iterable[ChatCompletionToolParam]] = None,
             workflow_run: Optional[SupportsWorkflowRun] = None,
@@ -149,6 +152,7 @@ class OpenAI:
             return self._agent.create_completion(
                 messages=messages,
                 model=model,
+                temperature=temperature,
                 tool_choice=tool_choice,
                 tools=tools,
                 response_model=response_model,

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -55,6 +55,7 @@ class BaseAgent(Protocol):
         workflow_run: Optional[SupportsWorkflowRun] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        temperature: Optional[float] = None,
         cache_mode: Optional[CacheMode] = "normal",
         **kwargs: Any,
     ) -> ChatCompletion[BaseModel]: ...
@@ -69,6 +70,7 @@ class BaseAgent(Protocol):
         workflow_run: Optional[SupportsWorkflowRun] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        temperature: Optional[float] = None,
         cache_mode: Optional[CacheMode] = "normal",
         **kwargs: Any,
     ) -> ChatCompletion[T_contra]: ...
@@ -82,6 +84,7 @@ class BaseAgent(Protocol):
         workflow_run: Optional[SupportsWorkflowRun] = None,
         tool_choice: Optional[ChatCompletionToolChoiceOptionParam] = None,
         tools: Optional[Iterable[ChatCompletionToolParam]] = None,
+        temperature: Optional[float] = None,
         cache_mode: Optional[CacheMode] = "normal",
         **kwargs: Any,
     ) -> ChatCompletion[T_contra]:

--- a/src/fixpoint/cache/__init__.py
+++ b/src/fixpoint/cache/__init__.py
@@ -2,13 +2,21 @@
 
 from typing import List
 
-from .protocol import SupportsCache, SupportsChatCompletionCache
-from .tlru import ChatCompletionTLRUCache
+from .protocol import (
+    SupportsCache,
+    SupportsChatCompletionCache,
+    CreateChatCompletionRequest,
+)
+from ._shared import parse_create_chat_completion_request
+from .chattlru import ChatCompletionTLRUCache, ChatCompletionTLRUCacheItem
 from .disktlru import ChatCompletionDiskTLRUCache
 
 __all__ = [
     "SupportsCache",
     "ChatCompletionTLRUCache",
+    "ChatCompletionTLRUCacheItem",
     "ChatCompletionDiskTLRUCache",
     "SupportsChatCompletionCache",
+    "CreateChatCompletionRequest",
+    "parse_create_chat_completion_request",
 ]

--- a/src/fixpoint/cache/_shared.py
+++ b/src/fixpoint/cache/_shared.py
@@ -1,12 +1,64 @@
 """shared internal code for the caching module"""
 
 import json
-from typing import Any
+from typing import (
+    cast,
+    Any,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    TypedDict,
+    TypeVar,
+)
 
+from pydantic import BaseModel
+
+from fixpoint.completions import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolChoiceOptionParam,
+    ChatCompletionToolParam,
+)
 from ..logging import logger as root_logger
 
 
 logger = root_logger.getChild("cache")
+
+
+BM = TypeVar("BM", bound=BaseModel)
+
+
+class CreateChatCompletionRequest(TypedDict, Generic[BM]):
+    """The arguments in a request to create a chat completion"""
+
+    messages: List[ChatCompletionMessageParam]
+    model: str
+    tool_choice: Optional[ChatCompletionToolChoiceOptionParam]
+    tools: Optional[Iterable[ChatCompletionToolParam]]
+    response_model: Optional[Type[BM]]
+    temperature: Optional[float]
+
+
+class _CreateChatCompletionRequestModel(BaseModel):
+    messages: List[ChatCompletionMessageParam]
+    model: str
+    tool_choice: Optional[ChatCompletionToolChoiceOptionParam]
+    tools: Optional[Iterable[ChatCompletionToolParam]]
+    response_model: Optional[BaseModel]
+    temperature: Optional[float]
+
+
+def parse_create_chat_completion_request(
+    data: Any,
+) -> CreateChatCompletionRequest[BaseModel]:
+    """Parse a chat completion request"""
+    if not isinstance(data, dict):
+        raise ValueError("expected a dictionary")
+    return cast(
+        CreateChatCompletionRequest[BaseModel],
+        _CreateChatCompletionRequestModel(**data).model_dump(),
+    )
 
 
 def serialize_any(key: Any) -> str:
@@ -14,3 +66,36 @@ def serialize_any(key: Any) -> str:
     if isinstance(key, (dict, list, set, str, int, float, bool)):
         return json.dumps(key)
     return str(key)
+
+
+def serialize_chat_completion_request(req: CreateChatCompletionRequest[BM]) -> str:
+    """Serialize a chat completion request"""
+    reqclone = dict(req)
+    resp_model = req["response_model"]
+    if resp_model is None:
+        reqclone["response_model"] = None
+    else:
+        reqclone["response_model"] = resp_model.model_json_schema()
+    return json.dumps(reqclone)
+
+
+def deserialize_chat_completion_request(
+    sreq: str, response_model: Optional[Type[BM]] = None
+) -> CreateChatCompletionRequest[BM]:
+    """Deserialize a chat completion request"""
+    parsed = json.loads(sreq)
+    if parsed["response_model"] is None and response_model is None:
+        parsed["response_model"] = None
+    elif parsed["response_model"] and response_model:
+        parsed["response_model"] = response_model
+    else:
+        print("DBM in error")
+        print(parsed["response_model"])
+        print(response_model)
+        raise TypeError("provided response_model and serialized response_model differ")
+
+    # Make sure the parsed object is valid
+    return cast(
+        CreateChatCompletionRequest[BM],
+        _CreateChatCompletionRequestModel(**parsed).model_dump(),
+    )

--- a/src/fixpoint/cache/_shared.py
+++ b/src/fixpoint/cache/_shared.py
@@ -89,9 +89,6 @@ def deserialize_chat_completion_request(
     elif parsed["response_model"] and response_model:
         parsed["response_model"] = response_model
     else:
-        print("DBM in error")
-        print(parsed["response_model"])
-        print(response_model)
         raise TypeError("provided response_model and serialized response_model differ")
 
     # Make sure the parsed object is valid

--- a/src/fixpoint/cache/chattlru.py
+++ b/src/fixpoint/cache/chattlru.py
@@ -3,43 +3,43 @@ TLRU Cache
 """
 
 import time
-import json
 from dataclasses import dataclass
 from threading import RLock
-from typing import Any, Callable, Generic, Union, Optional
+from typing import Any, Generic, Union, Optional, Type, cast
 from cachetools import TLRUCache as CachetoolsTLRUCache
 
+from pydantic import BaseModel
+
+from ..completions.chat_completion import ChatCompletion
 from .protocol import (
-    SupportsCache,
-    K_contra,
-    V,
+    SupportsChatCompletionCache,
+    CreateChatCompletionRequest,
 )
 from ..storage.protocol import SupportsStorage, SupportsSerialization
+from ._shared import (
+    BM,
+    serialize_chat_completion_request,
+    deserialize_chat_completion_request,
+)
 
 
-class TLRUCacheItem(SupportsSerialization["TLRUCacheItem[V]"], Generic[V]):
+class ChatCompletionTLRUCacheItem(
+    SupportsSerialization["ChatCompletionTLRUCacheItem[BM]"], Generic[BM]
+):
     """
     TLRU Cache Item
     """
 
-    _key: Any
-    _value: V
+    _key: CreateChatCompletionRequest[BM]
+    _value: ChatCompletion[BM]
     _ttl: float
     _expires_at: float
-    _serialize_fn: Callable[[Any], str] = (
-        json.dumps
-    )  # Default serialization function at class level
-    _deserialize_fn: Callable[[str], Any] = (
-        json.loads
-    )  # Default deserialization function at class level
 
     def __init__(
         self,
-        key: Any,
-        value: V,
+        key: CreateChatCompletionRequest[BM],
+        value: ChatCompletion[BM],
         ttl: float,
-        serialize_fn: Callable[[Any], str] = json.dumps,
-        deserialize_fn: Callable[[str], Any] = json.loads,
         expires_at: Union[float, None] = None,
     ) -> None:
         self._key = key
@@ -48,8 +48,6 @@ class TLRUCacheItem(SupportsSerialization["TLRUCacheItem[V]"], Generic[V]):
         self._expires_at = (
             expires_at if expires_at is not None else self._calc_expires_at()
         )
-        self._serialize_fn = serialize_fn
-        self._deserialize_fn = deserialize_fn
 
     def __repr__(self) -> str:
         return (
@@ -61,22 +59,22 @@ class TLRUCacheItem(SupportsSerialization["TLRUCacheItem[V]"], Generic[V]):
         return time.monotonic() + self._ttl
 
     @property
-    def key(self) -> Any:
+    def key(self) -> CreateChatCompletionRequest[BM]:
         """Get the key"""
         return self._key
 
     @key.setter
-    def key(self, key: K_contra) -> None:
+    def key(self, key: CreateChatCompletionRequest[BM]) -> None:
         """Set the key"""
         self._key = key
 
     @property
-    def value(self) -> V:
+    def value(self) -> ChatCompletion[BM]:
         """Get the value"""
         return self._value
 
     @value.setter
-    def value(self, value: V) -> None:
+    def value(self, value: ChatCompletion[BM]) -> None:
         """Set the value"""
         self._value = value
 
@@ -102,17 +100,27 @@ class TLRUCacheItem(SupportsSerialization["TLRUCacheItem[V]"], Generic[V]):
     def serialize(self) -> dict[str, Any]:
         """Convert the item to a dictionary"""
         return {
-            "key": self._serialize_fn(self._key),
-            "value": self._serialize_fn(self._value),
+            "key": serialize_chat_completion_request(self._key),
+            "value": self._value.serialize_json(),
             "ttl": self._ttl,
             "expires_at": self._expires_at,
         }
 
     @classmethod
-    def deserialize(cls, data: dict[str, Any]) -> "TLRUCacheItem[V]":
+    def deserialize(
+        cls, data: dict[str, Any], response_model: Optional[Type[BM]] = None
+    ) -> "ChatCompletionTLRUCacheItem[BM]":
         """Deserialize a dictionary into a TLRUCacheItem"""
-        key = cls._deserialize_fn(data.pop("key"))
-        value = cls._deserialize_fn(data.pop("value"))
+        print("DBM look")
+        print(response_model)
+        print(data)
+        key: CreateChatCompletionRequest[BM] = deserialize_chat_completion_request(
+            data.pop("key"),
+            response_model=response_model,
+        )
+        value: ChatCompletion[BM] = ChatCompletion.deserialize_json(
+            data.pop("value"), response_model
+        )
         expires_at = data.pop("expires_at")
         return cls(**data, key=key, value=value, expires_at=expires_at)
 
@@ -135,34 +143,38 @@ class StorageOptions:
         self.persist_to_storage = persist_to_storage
 
 
-class TLRUCache(SupportsCache[K_contra, V]):
-    """
-    TLRU Cache
-    """
+class ChatCompletionTLRUCache(SupportsChatCompletionCache):
+    """A TLRU cache for LLM inference requests"""
 
     _ttl_s: float
-    _serialize_key_fn: Callable[[K_contra], str]
-    cache: CachetoolsTLRUCache[str, TLRUCacheItem[V]]
-    _storage: Optional[SupportsStorage[TLRUCacheItem[V]]]
+
+    cache: CachetoolsTLRUCache[str, ChatCompletionTLRUCacheItem[BaseModel]]
+    _storage: Optional[SupportsStorage[ChatCompletionTLRUCacheItem[BaseModel]]]
     _storage_options: Optional[StorageOptions]
 
     def __init__(
         self,
         maxsize: int,
         ttl_s: float,
-        serialize_key_fn: Callable[[K_contra], str],
-        storage: Optional[SupportsStorage[TLRUCacheItem[V]]] = None,
+        storage: Optional[
+            SupportsStorage[ChatCompletionTLRUCacheItem[BaseModel]]
+        ] = None,
         storage_options: Optional[StorageOptions] = None,
     ) -> None:
         """
         max_size: the max number of items to keep in the cache
         ttl_s: the time-to-live in seconds per item
-        serialize_key_fn: a function that converts a key to a string for serialization
+        serialize_key_fn: a function that converts the key to a string for serialization
+        deserialize_key_fn: a function that converts a string to the key for deserialization
+        serialize_value_fn: a function that converts the value to a string for serialization
+        deserialize_value_fn: a function that converts a string to the value for deserialization
         storage: an optional storage to persist the cache to
         storage_options: if storage is specified, this lets you configure it
         """
 
-        def my_ttu(_key: str, value: TLRUCacheItem[V], now: float) -> float:
+        def my_ttu(
+            _key: str, value: ChatCompletionTLRUCacheItem[BaseModel], now: float
+        ) -> float:
             # assume value.ttl contains the item's time-to-live in seconds
             return now + value.ttl
 
@@ -184,7 +196,6 @@ class TLRUCache(SupportsCache[K_contra, V]):
 
         self.lock = RLock()
         self._ttl_s = ttl_s
-        self._serialize_key_fn = serialize_key_fn
 
         if self._supports_init_from_storage():
             self._init_from_storage()
@@ -215,7 +226,8 @@ class TLRUCache(SupportsCache[K_contra, V]):
                 item for item in deserialized_results if item.expires_at >= current_time
             ]
             for cache_item in non_expired_items:
-                _key = self._serialize_key(cache_item.key)
+                # TODO(dbmikus) this does not load in the structured output
+                _key: str = serialize_chat_completion_request(cache_item.key)
                 self.cache[_key] = cache_item
 
             # Remove expired items from the storage
@@ -223,33 +235,53 @@ class TLRUCache(SupportsCache[K_contra, V]):
                 item for item in deserialized_results if item.expires_at < current_time
             ]
             for cache_item in expired_items:
-                _key = self._serialize_key(cache_item.key)
+                _key = serialize_chat_completion_request(cache_item.key)
                 self._storage.delete(_key)
 
-    def _serialize_key(self, key: K_contra) -> str:
-        return self._serialize_key_fn(key)
-
-    def get(self, key: K_contra) -> Union[Any, None]:
+    def get(
+        self,
+        key: CreateChatCompletionRequest[BM],
+        response_model: Optional[Type[BM]] = None,
+    ) -> Union[ChatCompletion[BM], None]:
         with self.lock:
             # Pre-emptively expire any expired items
             self.cache.expire()
-            _key = self._serialize_key(key)
+            _key = serialize_chat_completion_request(key)
             item = self.cache.get(_key)
             if item is not None:
-                return item.value
+                if response_model is None:
+                    if item.value.fixp.structured_output is not None:
+                        raise ValueError(
+                            "the completion's structured output should be None"
+                        )
+                    return cast(ChatCompletion[BM], item.value)
+                elif not isinstance(item.value.fixp.structured_output, response_model):
+                    raise ValueError(
+                        f"Item's structured_output should be of type: {response_model}"
+                    )
+                return cast(ChatCompletion[BM], item.value)
             return None
 
-    def set(self, key: K_contra, value: V) -> None:
+    def set(
+        self, key: CreateChatCompletionRequest[BM], value: ChatCompletion[BM]
+    ) -> None:
         with self.lock:
-            _key = self._serialize_key(key)
-            cache_item = TLRUCacheItem(key, value, self._ttl_s)
-            self.cache[_key] = cache_item
+            cache_item = ChatCompletionTLRUCacheItem(
+                key,
+                value,
+                self._ttl_s,
+            )
+            self.cache[serialize_chat_completion_request(key)] = cast(
+                ChatCompletionTLRUCacheItem[BaseModel], cache_item
+            )
             if self._supports_persist_to_storage() and self._storage is not None:
-                self._storage.insert(cache_item)
+                self._storage.insert(
+                    cast(ChatCompletionTLRUCacheItem[BaseModel], cache_item)
+                )
 
-    def delete(self, key: K_contra) -> None:
+    def delete(self, key: CreateChatCompletionRequest[BM]) -> None:
         with self.lock:
-            _key = self._serialize_key(key)
+            _key = serialize_chat_completion_request(key)
             del self.cache[_key]
             if self._supports_persist_to_storage() and self._storage is not None:
                 self._storage.delete(_key)

--- a/src/fixpoint/cache/chattlru.py
+++ b/src/fixpoint/cache/chattlru.py
@@ -111,9 +111,6 @@ class ChatCompletionTLRUCacheItem(
         cls, data: dict[str, Any], response_model: Optional[Type[BM]] = None
     ) -> "ChatCompletionTLRUCacheItem[BM]":
         """Deserialize a dictionary into a TLRUCacheItem"""
-        print("DBM look")
-        print(response_model)
-        print(data)
         key: CreateChatCompletionRequest[BM] = deserialize_chat_completion_request(
             data.pop("key"),
             response_model=response_model,

--- a/src/fixpoint/cache/chattlru.py
+++ b/src/fixpoint/cache/chattlru.py
@@ -1,5 +1,5 @@
 """
-TLRU Cache
+TLRU Cache for chat completions
 """
 
 import time

--- a/tests/cache/disktlru_test.py
+++ b/tests/cache/disktlru_test.py
@@ -1,23 +1,42 @@
-from typing import List
+from fixpoint.completions import ChatCompletion
+from fixpoint.cache.disktlru import ChatCompletionDiskTLRUCache
+from fixpoint.cache.protocol import CreateChatCompletionRequest
+from fixpoint.agents.mock import new_mock_completion
 
-from fixpoint.cache.disktlru import DiskTLRUCache
-from fixpoint.completions import ChatCompletionMessageParam
+from pydantic import BaseModel
+
+
+class MyModel(BaseModel):
+    name: str
+    age: int
 
 
 class TestDiskTLRUCache:
     def test_messages_serialize(self) -> None:
-        cache = DiskTLRUCache[List[ChatCompletionMessageParam], str].from_tmpdir(
+        cache = ChatCompletionDiskTLRUCache.from_tmpdir(
             size_limit_bytes=1024 * 1024, ttl_s=10
         )
 
+        req: CreateChatCompletionRequest[MyModel] = {
+            "messages": [{"role": "user", "content": "something goes here"}],
+            "model": "gpt-3.5-turbo",
+            "response_model": MyModel,
+            "temperature": None,
+            "tool_choice": None,
+            "tools": None,
+        }
+
         cache.set(
-            [{"role": "user", "content": "something goes here"}],
-            "this is a faked response",
+            req,
+            new_mock_completion(
+                "this is a faked response", MyModel(name="John", age=20)
+            ),
         )
 
         # make sure that if we create a new list but it has the same contents,
         # we get the same response
-        assert (
-            cache.get([{"role": "user", "content": "something goes here"}])
-            == "this is a faked response"
+        assert cache.get(
+            CreateChatCompletionRequest(**req), MyModel
+        ) == new_mock_completion(
+            "this is a faked response", MyModel(name="John", age=20)
         )

--- a/tests/cache/test_chat_completion_cache.py
+++ b/tests/cache/test_chat_completion_cache.py
@@ -1,0 +1,169 @@
+from dataclasses import dataclass
+import pytest
+from typing import Tuple
+
+from pydantic import BaseModel
+
+from fixpoint.storage.supabase import SupabaseStorage
+from fixpoint.agents.mock import new_mock_completion
+from fixpoint.completions.chat_completion import ChatCompletion
+from fixpoint.cache import (
+    SupportsChatCompletionCache,
+    CreateChatCompletionRequest,
+    ChatCompletionDiskTLRUCache,
+    ChatCompletionTLRUCache,
+    ChatCompletionTLRUCacheItem,
+)
+from ..supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
+
+
+class MyModel(BaseModel):
+    name: str
+    age: int
+
+
+class TestChatCompletionCache:
+    @pytest.mark.skipif(
+        not is_supabase_enabled(),
+        reason="Disabled until we have a supabase instance running in CI",
+    )
+    @pytest.mark.parametrize(
+        "supabase_setup_url_and_key",
+        [
+            (
+                f"""
+        CREATE TABLE IF NOT EXISTS public.completion_cache (
+            key text PRIMARY KEY,
+            value jsonb,
+            ttl float,
+            expires_at float
+        );
+
+        TRUNCATE TABLE public.completion_cache
+        """,
+                "public.completion_cache",
+            )
+        ],
+        indirect=True,
+    )
+    def test_storage_tlru_cache(
+        self, supabase_setup_url_and_key: Tuple[str, str]
+    ) -> None:
+        url, key = supabase_setup_url_and_key
+        storage = SupabaseStorage(
+            url,
+            key,
+            table="completion_cache",
+            order_key="expires_at",
+            id_column="key",
+            # We cannot not specify the generic type parameter for
+            # TLRUCacheItem, because then when we try to do `isinstance(cls,
+            # type)`, the class will actually be a `typing.GenericAlias` and not
+            # a type (class definition).
+            value_type=ChatCompletionTLRUCacheItem,
+        )
+        cache = ChatCompletionTLRUCache(maxsize=50, ttl_s=60 * 60, storage=storage)
+        self.assert_cache_hits(cache)
+
+    def test_tlru_cache(self) -> None:
+        cache = ChatCompletionTLRUCache(maxsize=50, ttl_s=60 * 60)
+        self.assert_cache_hits(cache)
+
+    def test_disk_tlru_cache(self) -> None:
+        cache = ChatCompletionDiskTLRUCache.from_tmpdir(
+            size_limit_bytes=1024 * 1024, ttl_s=10
+        )
+        self.assert_cache_hits(cache)
+
+    def assert_cache_hits(self, cache: SupportsChatCompletionCache) -> None:
+        req: CreateChatCompletionRequest[MyModel] = {
+            "messages": [{"role": "user", "content": "something goes here"}],
+            "model": "gpt-3.5-turbo",
+            "response_model": MyModel,
+            "temperature": None,
+            "tool_choice": None,
+            "tools": None,
+        }
+
+        cache.set(
+            req,
+            new_mock_completion(
+                "this is a faked response", MyModel(name="John", age=20)
+            ),
+        )
+
+        # make sure that if we create a new list but it has the same contents,
+        # we get the same response
+        assert cache.get(
+            CreateChatCompletionRequest(**req), MyModel
+        ) == new_mock_completion(
+            "this is a faked response", MyModel(name="John", age=20)
+        )
+
+        @dataclass
+        class TestCase:
+            old_req: CreateChatCompletionRequest[MyModel]
+            new_req: CreateChatCompletionRequest[MyModel]
+            old_resp: ChatCompletion[MyModel]
+            new_resp: ChatCompletion[MyModel]
+
+        req2 = req.copy()
+        req2["temperature"] = 0.5
+        req3 = req.copy()
+        req3["model"] = "gpt-4"
+        test_cases = [
+            TestCase(
+                old_req=req,
+                new_req=req2,
+                old_resp=new_mock_completion(
+                    "this is a faked response", MyModel(name="John", age=20)
+                ),
+                new_resp=new_mock_completion(
+                    "another faked response", MyModel(name="Bob", age=86)
+                ),
+            ),
+            TestCase(
+                old_req=req,
+                new_req=req3,
+                old_resp=new_mock_completion(
+                    "this is a faked response", MyModel(name="John", age=20)
+                ),
+                new_resp=new_mock_completion(
+                    "new model response", MyModel(name="Susy", age=42)
+                ),
+            ),
+        ]
+
+        for tc in test_cases:
+            assert cache.get(tc.new_req) is None
+            cache.set(tc.new_req, tc.new_resp)
+            assert cache.get(tc.old_req, MyModel) == tc.old_resp
+            assert cache.get(tc.new_req, MyModel) == tc.new_resp
+
+        # # Try changing the temperature, and we should get a different response
+        # req2 = req.copy()
+        # req2["temperature"] = 0.5
+        # assert cache.get(CreateChatCompletionRequest(**req2), MyModel) is None
+        # cache.set(req2, new_mock_completion("another faked response", MyModel(name="Bob", age=90)))
+        # assert (
+        #     cache.get(CreateChatCompletionRequest(**req2), MyModel)
+        #     == new_mock_completion("another faked response", MyModel(name="Bob", age=90))
+        # )
+        # assert (
+        #     cache.get(CreateChatCompletionRequest(**req), MyModel)
+        #     == new_mock_completion("this is a faked response", MyModel(name="John", age=20))
+        # )
+
+        # # Try changing the model, and we should get a different response
+        # req3 = req.copy()
+        # req3["model"] = "gpt-4"
+        # assert cache.get(CreateChatCompletionRequest(**req3), MyModel) is None
+        # cache.set(req3, new_mock_completion("another faked response", MyModel(name="Susy", age=42)))
+        # assert (
+        #     cache.get(CreateChatCompletionRequest(**req3), MyModel)
+        #     == new_mock_completion("another faked response", MyModel(name="Susy", age=42))
+        # )
+        # assert (
+        #     cache.get(CreateChatCompletionRequest(**req), MyModel)
+        #     == new_mock_completion("this is a faked response", MyModel(name="John", age=20))
+        # )

--- a/tests/cache/tlru_test.py
+++ b/tests/cache/tlru_test.py
@@ -11,7 +11,9 @@ class TestTLRUCache:
 
     def test_tlru_cache_size_limits(self) -> None:
         ttlCache = TLRUCache[str, str](
-            maxsize=1, ttl_s=1000, serialize_key_fn=json.dumps
+            maxsize=1,
+            ttl_s=1000,
+            serialize_key_fn=json.dumps,
         )
         ttlCache.set("test", "a")
         ttlCache.set("test2", "b")
@@ -25,7 +27,11 @@ class TestTLRUCache:
 
     @freeze_time("2023-01-01 00:00:00")
     def test_tlru_cache_ttl(self) -> None:
-        ttlCache = TLRUCache[str, str](maxsize=1, ttl_s=10, serialize_key_fn=json.dumps)
+        ttlCache = TLRUCache[str, str](
+            maxsize=1,
+            ttl_s=10,
+            serialize_key_fn=json.dumps,
+        )
         ttlCache.set("test", "a")
         assert ttlCache.get("test") == "a"
 
@@ -96,7 +102,10 @@ class TestTLRUCacheWithStorage:
         )
 
         cache = TLRUCache[list[dict[str, str]], str](
-            maxsize=10, ttl_s=10, serialize_key_fn=json.dumps, storage=storage
+            maxsize=10,
+            ttl_s=10,
+            storage=storage,
+            serialize_key_fn=json.dumps,
         )
 
         item_key = completion.request
@@ -118,13 +127,19 @@ class TestTLRUCacheWithStorage:
 
         # Instantiate cache from data, we should get one item in the cache
         new_cache = TLRUCache[list[dict[str, str]], str](
-            maxsize=10, ttl_s=10, serialize_key_fn=json.dumps, storage=storage
+            maxsize=10,
+            ttl_s=10,
+            storage=storage,
+            serialize_key_fn=json.dumps,
         )
         assert new_cache.get(item_key) == item_value
         # Instantiate cache from data, after ttl has expired, we should get no items in the cache
         with freeze_time("2023-01-01 00:00:22"):
             another_cache = TLRUCache[list[dict[str, str]], str](
-                maxsize=10, ttl_s=10, serialize_key_fn=json.dumps, storage=storage
+                maxsize=10,
+                ttl_s=10,
+                storage=storage,
+                serialize_key_fn=json.dumps,
             )
             # Not initialized with any data from the storage
             assert another_cache.get(item_key) is None

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -1,7 +1,10 @@
-from typing import List, Tuple
 import json
 import pytest
-from fixpoint.completions import ChatCompletionMessageParam
+from typing import List, Tuple
+
+from pydantic import BaseModel
+
+from fixpoint.completions import ChatCompletionMessageParam, ChatCompletion
 from fixpoint.memory import Memory, MemoryItem
 from fixpoint.agents.mock import new_mock_completion
 from fixpoint.storage.supabase import SupabaseStorage
@@ -15,7 +18,7 @@ class TestWithMemory:
         msgs: List[ChatCompletionMessageParam] = [
             {"role": "system", "content": "hello!"}
         ]
-        cmpl = new_mock_completion()
+        cmpl: ChatCompletion[BaseModel] = new_mock_completion()
         memstore.store_memory(msgs, cmpl)
 
         stored_memory = memstore.memories()
@@ -73,7 +76,7 @@ class TestWithMemoryWithStorage:
         msgs: List[ChatCompletionMessageParam] = [
             {"role": "system", "content": "hello!"}
         ]
-        cmpl = new_mock_completion()
+        cmpl: ChatCompletion[BaseModel] = new_mock_completion()
         memstore.store_memory(msgs, cmpl)
 
         stored_memory = memstore.memories()


### PR DESCRIPTION
When we make a chat completion request, we used to only do caching based on the "messages" parameter. However, there are a bunch of other model parameters that affect the response, such as the model used or the temperature.

Now, we cache based on more completion request parameters. We don't cover all arguments to OpenAI yet, but more of them.

Along the way, I tried to make serialization and deserialization of work for pairs of:

- CreateChatCompletionRequest
- ChatCompletion

The problem here is that both of these types contain a Pydantic model class and instance, respectively. This type does not serialize or deserialize cleanly. You must know what class to use when deserializing.

We kind of kludge this into working for now. It was difficult for me to use the `TLRUCache`. I tried to get that working, but kept running into problems. So instead of the `ChatCompletionTLRUCache` inheriting from the `TLRUCache`, it is now a totally separate class.

For the most part, it serialization and deserialization now works, both for the cache and for Supabase storage.