### PR TITLE
Fix a few bugs in structured workflow example

### DIFF
--- a/src/fixpoint_extras/workflows/structured/_task.py
+++ b/src/fixpoint_extras/workflows/structured/_task.py
@@ -220,7 +220,7 @@ def get_task_entrypoint_fixp_from_fn(fn: Callable[..., Any]) -> Optional[TaskEnt
     return None
 
 
-async def call_task(
+def call_task(
     ctx: WorkflowContext,
     task_entry: Callable[Params, Ret],
     args: Optional[List[Any]] = None,

--- a/tests/extras/workflows/structured/test_task.py
+++ b/tests/extras/workflows/structured/test_task.py
@@ -54,7 +54,7 @@ async def test_call_task() -> None:
     @structured.task("my-task")
     class MyTask:
         @structured.task_entrypoint()
-        def run(self, ctx: structured.WorkflowContext, name_to_print: str) -> str:
+        async def run(self, ctx: structured.WorkflowContext, name_to_print: str) -> str:
             return f"Hello, {name_to_print}"
 
     workflow = imperative.Workflow(id="my-workflow")

--- a/tests/workflows/imperative/test_workflow.py
+++ b/tests/workflows/imperative/test_workflow.py
@@ -1,0 +1,16 @@
+from fixpoint_extras.workflows.imperative.workflow import NodeState
+
+
+class TestNodeState:
+    def test_id(self) -> None:
+        node = NodeState()
+        assert node.id == "/"
+
+        node = NodeState(task="test_task", step="test_step")
+        assert node.id == "/test_task/test_step"
+
+        node = NodeState(task="test_task")
+        assert node.id == "/test_task"
+
+        node = NodeState(step="test_step")
+        assert node.id == "/__main__/test_step"


### PR DESCRIPTION
Fix a few bugs in the structured workflow example so that it runs. Also, use `TaskGroup` for structured concurrency to wait on multiple coroutines. Structured concurrency is a more readable pattern for knowing when all concurrent calls are finished.

Make a few updates to how we represent the workflow node-state path-like ID string. If we are in the main task or step (aka no task or step specified), then we omit that part from the path ID.

When you store a document or form, by default we store it at the workflow's current node.