### PR TITLE
Rework setup code for workflows and agents

### DIFF
--- a/examples/structured_workflow.py
+++ b/examples/structured_workflow.py
@@ -39,8 +39,6 @@ def init_workflow_context(workflow_run: WorkflowRun) -> WorkflowContext:
     return WorkflowContext.from_workflow(
         workflow_run,
         agents={"gpt3": gpt3, "gpt4": gpt4},
-        # TODO(dbmikus) remove this and require users to pull the memory off the agents
-        memory=memory,
         cache=cache,
     )
 

--- a/src/fixpoint/agents/_memgpt.py
+++ b/src/fixpoint/agents/_memgpt.py
@@ -23,7 +23,7 @@ from typing import Any, List, Optional, Type, TypeVar, Union, overload
 from pydantic import BaseModel
 
 from ..logging import logger
-from ..agents.protocol import BaseAgent
+from .protocol import BaseAgent
 from ..completions import ChatCompletionMessageParam, ChatCompletion
 from ..workflows import SupportsWorkflowRun
 

--- a/src/fixpoint/agents/mock.py
+++ b/src/fixpoint/agents/mock.py
@@ -27,7 +27,7 @@ from ..completions import (
     ChatCompletionToolParam,
     ChatCompletionToolChoiceOptionParam,
 )
-from ..memory import SupportsMemory
+from ..memory import SupportsMemory, NoOpMemory
 from ..workflows import SupportsWorkflowRun
 from .protocol import BaseAgent, CompletionCallback, PreCompletionFn
 from ._shared import request_cached_completion, CacheMode
@@ -42,7 +42,7 @@ class MockAgent(BaseAgent):
     _completion_fn: Callable[[], ChatCompletion[BaseModel]]
     _pre_completion_fns: List[PreCompletionFn]
     _completion_callbacks: List[CompletionCallback]
-    _memory: Optional[SupportsMemory] = None
+    memory: SupportsMemory
     _cache_mode: CacheMode = "normal"
     _model: str
 
@@ -58,7 +58,7 @@ class MockAgent(BaseAgent):
         self._completion_fn = completion_fn
         self._pre_completion_fns = pre_completion_fns or []
         self._completion_callbacks = completion_callbacks or []
-        self._memory = memory
+        self.memory = memory or NoOpMemory()
         self._cache = cache
         self._model = model
 
@@ -127,8 +127,8 @@ class MockAgent(BaseAgent):
         )
 
         casted_cmpl = cast(ChatCompletion[BaseModel], cmpl)
-        if self._memory:
-            self._memory.store_memory(
+        if self.memory:
+            self.memory.store_memory(
                 messages=messages, completion=casted_cmpl, workflow_run=workflow_run
             )
         self._trigger_completion_callbacks(messages, casted_cmpl)

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -34,7 +34,7 @@ from ..completions import (
     ChatCompletionToolChoiceOptionParam,
     ChatCompletionToolParam,
 )
-from ..memory import SupportsMemory
+from ..memory import SupportsMemory, NoOpMemory
 from ..workflows import SupportsWorkflowRun
 from .protocol import BaseAgent, CompletionCallback, PreCompletionFn
 from ._shared import request_cached_completion, CacheMode
@@ -105,7 +105,7 @@ class OpenAIAgent(BaseAgent):
     _openai_clients: OpenAIClients
     _completion_callbacks: List[CompletionCallback]
     _pre_completion_fns: List[PreCompletionFn]
-    _memory: Optional[SupportsMemory]
+    memory: SupportsMemory
     _cache_mode: CacheMode = "normal"
 
     def __init__(
@@ -129,7 +129,7 @@ class OpenAIAgent(BaseAgent):
 
         self._completion_callbacks = completion_callbacks or []
         self._pre_completion_fns = pre_completion_fns or []
-        self._memory = memory
+        self.memory = memory or NoOpMemory()
         self._cache = cache
 
     def create_completion(
@@ -180,8 +180,8 @@ class OpenAIAgent(BaseAgent):
         )
 
         basemodel_fixp_completion = cast(ChatCompletion[BaseModel], fixp_completion)
-        if self._memory is not None:
-            self._memory.store_memory(messages, basemodel_fixp_completion, workflow_run)
+        if self.memory is not None:
+            self.memory.store_memory(messages, basemodel_fixp_completion, workflow_run)
         self._trigger_completion_callbacks(messages, basemodel_fixp_completion)
         return fixp_completion
 

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -20,6 +20,7 @@ from fixpoint.completions import (
     ChatCompletionToolChoiceOptionParam,
     ChatCompletionToolParam,
 )
+from fixpoint.memory import SupportsMemory
 from ..workflows import SupportsWorkflowRun
 from ._shared import CacheMode
 
@@ -29,6 +30,8 @@ T_contra = TypeVar("T_contra", bound=BaseModel, contravariant=True)
 
 class BaseAgent(Protocol):
     """The base protocol for agents"""
+
+    memory: SupportsMemory
 
     # We create overloaded versions of the `create_completion` method so that we
     # can infer whether the returned `ChatCompletion` should have a type

--- a/src/fixpoint/memory/__init__.py
+++ b/src/fixpoint/memory/__init__.py
@@ -1,13 +1,11 @@
 """LLM agent memory"""
 
-from ._memgpt import MemGPTSummarizeOpts, MemGPTSummaryAgent, memgpt_summarize
 from ._memory import Memory, SupportsMemory, MemoryItem
+from ._no_op_memory import NoOpMemory
 
 __all__ = [
-    "MemGPTSummarizeOpts",
-    "MemGPTSummaryAgent",
     "Memory",
     "SupportsMemory",
     "MemoryItem",
-    "memgpt_summarize",
+    "NoOpMemory",
 ]

--- a/src/fixpoint/memory/_no_op_memory.py
+++ b/src/fixpoint/memory/_no_op_memory.py
@@ -1,0 +1,29 @@
+"""A memory class that stores no memories."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from fixpoint.completions import ChatCompletionMessageParam, ChatCompletion
+from fixpoint.workflows import SupportsWorkflowRun
+from ._memory import SupportsMemory, MemoryItem
+
+
+class NoOpMemory(SupportsMemory):
+    """A memory class that stores no memories."""
+
+    def memories(self) -> List[MemoryItem]:
+        """Get the list of memories"""
+        return []
+
+    def store_memory(
+        self,
+        messages: List[ChatCompletionMessageParam],
+        completion: ChatCompletion[BaseModel],
+        workflow_run: Optional[SupportsWorkflowRun] = None,
+    ) -> None:
+        """Store the memory"""
+
+    def to_str(self) -> str:
+        """Return the formatted string of messages. Useful for printing/debugging"""
+        return ""

--- a/src/fixpoint_extras/services/formagent/setup.py
+++ b/src/fixpoint_extras/services/formagent/setup.py
@@ -23,7 +23,6 @@ def setup_workflow(
     Set up the workflow context, which includes the workflow ojbect, the agent,
     the agent's memory store, and a logger for the workflow.
     """
-    agent_mem = DataframeMemory()
     # Log token usage
     tokenlogger = TikTokenLogger(model_name)
     agent = fixpoint.agents.OpenAIAgent(
@@ -31,13 +30,11 @@ def setup_workflow(
         openai_clients=OpenAIClients.from_api_key(
             openai_key, base_url=openai_base_url, default_headers=default_openai_headers
         ),
-        memory=agent_mem,
+        memory=DataframeMemory(),
         pre_completion_fns=[tokenlogger.tiktoken_logger],
         cache=cache,
     )
 
     workflow_run = Workflow(id="form_filler_agent").run()
 
-    return WorkflowContext.from_workflow(
-        workflow_run, {"main": agent}, agent_mem, cache
-    )
+    return WorkflowContext.from_workflow(workflow_run, {"main": agent}, cache)

--- a/src/fixpoint_extras/workflows/structured/_workflow.py
+++ b/src/fixpoint_extras/workflows/structured/_workflow.py
@@ -258,9 +258,9 @@ def run_workflow(
     workflow_entry: Callable[Params, Ret],
     args: Optional[Sequence[Any]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
+    ctx_factory: Optional[CtxFactory] = None,
 ) -> Ret:
     """Runs a structured workflow.
-
 
     You must call `call_task` from within a structured workflow definition. ie
     from a class decorated with `@structured.workflow(...)`. A more complete example:
@@ -275,6 +275,9 @@ def run_workflow(
 
     structured.run_workflow(MyWorkflow.main, args=[{"somevalue": "foobar"}])
     ```
+
+    If you pass in a `ctx_factory`, it will be used instead of the `ctx_factory`
+    defined on the workflow class.
     """
     entryfixp = get_workflow_entrypoint_fixp(workflow_entry)
     if not entryfixp:
@@ -298,7 +301,7 @@ def run_workflow(
         raise DefinitionException(
             f'Workflow "{workflow_defn.__name__}" is not a valid workflow instance'
         )
-    fixp.run(fixpmeta.ctx_factory)
+    fixp.run(ctx_factory or fixpmeta.ctx_factory)
 
     if not fixp.ctx:
         # this is an internal error, not a user error

--- a/src/fixpoint_extras/workflows/structured/_workflow.py
+++ b/src/fixpoint_extras/workflows/structured/_workflow.py
@@ -137,7 +137,6 @@ def _default_ctx_factory(run: WorkflowRun) -> WorkflowContext:
     return WorkflowContext.from_workflow(
         workflow_run=run,
         agents={},
-        memory=fixpoint.memory.Memory(),
         # TODO(dbmikus) change default to an in-memory cache
         cache=fixpoint.cache.ChatCompletionDiskTLRUCache.from_tmpdir(
             # 1 hour

--- a/tests/agents/test_memgpt.py
+++ b/tests/agents/test_memgpt.py
@@ -5,12 +5,12 @@ from pydantic import BaseModel
 from fixpoint.memory import Memory
 from fixpoint.completions import ChatCompletion, ChatCompletionMessageParam
 from fixpoint.agents.mock import MockAgent, new_mock_completion
-from fixpoint.utils.messages import smsg, umsg
-from fixpoint.memory._memgpt import (
+from fixpoint.agents._memgpt import (
     MemGPTSummaryAgent,
     MemGPTSummarizeOpts,
     _ContextLengthCheck,
 )
+from fixpoint.utils.messages import smsg, umsg
 
 
 class TestMemGPTSummaryAgent:

--- a/tests/extras/workflows/structured/test_step.py
+++ b/tests/extras/workflows/structured/test_step.py
@@ -50,6 +50,5 @@ def new_workflow_context(workflow_id: str) -> structured.WorkflowContext:
     ctx = structured.WorkflowContext.from_workflow(
         wrun,
         agents={},
-        memory=fixpoint.memory.Memory(),
     )
     return ctx

--- a/tests/extras/workflows/structured/test_task.py
+++ b/tests/extras/workflows/structured/test_task.py
@@ -62,7 +62,6 @@ async def test_call_task() -> None:
     ctx = structured.WorkflowContext.from_workflow(
         wrun,
         agents={},
-        memory=fixpoint.memory.Memory(),
     )
     res = await structured.call_task(ctx, MyTask.run, args=["Dylan"])
     assert res == "Hello, Dylan"


### PR DESCRIPTION
Rework some setup code for workflows and agents. Changes:

**Agent and memory changes**

Agents now have a `memory` field, which is how you can refer to an agent's memory. Before, you would pass in a memory container but there was no way to access the memory container.

Memory is required on all agents. If you don't supply a memory container, we'll use a no-op memory container that doesn't actually store memories. This makes it easier for the rest of the code to assume that we are storing memories.

I had to move the `_memgpt.py` file so that we no longer had a circular import, which was causing a Pylint error.

**Workflow changes**

The `WorkflowContext` is no longer a dataclass, so we have control over its initialization.

`WorkflowContext` no longer accepts a memory field. Instead, the agents all have memory containers themselves.