### PR TITLE
Set up factories for workflow storage

### DIFF
--- a/db/migrations/20240624012918_mem-cache-docs-and-forms.sql
+++ b/db/migrations/20240624012918_mem-cache-docs-and-forms.sql
@@ -1,0 +1,59 @@
+-- migrate:up
+CREATE TABLE public.memory_store (
+    id text PRIMARY KEY,
+    agent_id text NOT NULL,
+    messages jsonb NOT NULL,
+    completion jsonb,
+    workflow_id text,
+    workflow_run_id text
+);
+
+CREATE INDEX idx_memory_store_agent_id ON public.memory_store (agent_id);
+CREATE INDEX idx_memory_store_workflow_id ON public.memory_store (workflow_id);
+CREATE INDEX idx_memory_store_workflow_run_id ON public.memory_store (workflow_run_id);
+
+
+CREATE TABLE public.completion_cache (
+    key text PRIMARY KEY,
+    value jsonb NOT NULL,
+    ttl float NOT NULL,
+    expires_at float NOT NULL
+);
+
+
+CREATE TABLE public.documents (
+    -- TODO(dbmikus) how do id and path relate?
+    id text PRIMARY KEY,
+    workflow_id text,
+    workflow_run_id text,
+    path text NOT NULL,
+    metadata jsonb NOT NULL,
+    contents text NOT NULL
+);
+
+CREATE INDEX idx_documents_path ON public.documents (path);
+
+
+CREATE TABLE public.forms_with_metadata (
+    -- TODO(dbmikus) how do id and path relate?
+    id text PRIMARY KEY,
+    workflow_id text,
+    workflow_run_id text,
+    metadata jsonb,
+    path text NOT NULL,
+    contents jsonb NOT NULL,
+    form_schema text NOT NULL,
+    versions jsonb,
+    task text,
+    step text
+);
+
+CREATE INDEX idx_forms_workflow_run_id ON public.forms_with_metadata (workflow_run_id);
+CREATE INDEX idx_forms_path ON public.forms_with_metadata (path);
+CREATE INDEX idx_forms_path ON public.forms_with_metadata (task, step);
+
+
+-- migrate:down
+DROP TABLE public.completion_cache;
+DROP TABLE public.documents;
+DROP TABLE public.forms_with_metadata;

--- a/examples/structured_workflow.py
+++ b/examples/structured_workflow.py
@@ -25,12 +25,14 @@ def init_workflow_context(workflow_run: WorkflowRun) -> WorkflowContext:
     memory = DataframeMemory()
     # TODO(dbmikus) expose memory on an agent
     gpt3 = OpenAIAgent(
+        agent_id="gpt3",
         model_name="gpt-3.5-turbo",
         openai_clients=openaiclients,
         memory=memory,
         cache=cache,
     )
     gpt4 = OpenAIAgent(
+        agent_id="gpt4",
         model_name="gpt-4-turbo",
         openai_clients=openaiclients,
         memory=DataframeMemory(),
@@ -38,7 +40,7 @@ def init_workflow_context(workflow_run: WorkflowRun) -> WorkflowContext:
     )
     return WorkflowContext.from_workflow(
         workflow_run,
-        agents={"gpt3": gpt3, "gpt4": gpt4},
+        agents=[gpt3, gpt4],
         cache=cache,
     )
 

--- a/src/fixpoint/agents/__init__.py
+++ b/src/fixpoint/agents/__init__.py
@@ -4,7 +4,7 @@ This is the agents module.
 
 from .protocol import BaseAgent
 from .openai import OpenAIAgent
-from ._shared import CacheMode
+from ._shared import CacheMode, random_agent_id
 from . import oai
 
-__all__ = ["BaseAgent", "OpenAIAgent", "CacheMode", "oai"]
+__all__ = ["BaseAgent", "OpenAIAgent", "CacheMode", "oai", "random_agent_id"]

--- a/src/fixpoint/agents/_shared.py
+++ b/src/fixpoint/agents/_shared.py
@@ -1,6 +1,7 @@
 """Internal shared code for the "agents" module."""
 
 from typing import Callable, Optional, Literal, TypeVar
+import uuid
 
 from pydantic import BaseModel
 
@@ -45,3 +46,8 @@ def request_cached_completion(
             cache.set(req, cmpl)
 
     return cmpl
+
+
+def random_agent_id() -> str:
+    """Generate a random agent ID if not explicitly given"""
+    return "agent-" + str(uuid.uuid4())

--- a/src/fixpoint/agents/oai/openai.py
+++ b/src/fixpoint/agents/oai/openai.py
@@ -43,6 +43,7 @@ class OpenAI:
 
     def __init__(
         self,
+        agent_id: str,
         model_name: str,
         openai_clients: OpenAIClients,
         *,
@@ -52,6 +53,7 @@ class OpenAI:
         cache: Optional[SupportsChatCompletionCache] = None,
     ) -> None:
         self.fixp = OpenAIAgent(
+            agent_id=agent_id,
             model_name=model_name,
             openai_clients=openai_clients,
             pre_completion_fns=pre_completion_fns,

--- a/src/fixpoint/agents/openai.py
+++ b/src/fixpoint/agents/openai.py
@@ -105,11 +105,14 @@ class OpenAIAgent(BaseAgent):
     _openai_clients: OpenAIClients
     _completion_callbacks: List[CompletionCallback]
     _pre_completion_fns: List[PreCompletionFn]
-    memory: SupportsMemory
     _cache_mode: CacheMode = "normal"
+
+    memory: SupportsMemory
+    id: str
 
     def __init__(
         self,
+        agent_id: str,
         model_name: str,
         openai_clients: OpenAIClients,
         *,
@@ -131,6 +134,8 @@ class OpenAIAgent(BaseAgent):
         self._pre_completion_fns = pre_completion_fns or []
         self.memory = memory or NoOpMemory()
         self._cache = cache
+
+        self.id = agent_id
 
     def create_completion(
         self,
@@ -181,7 +186,9 @@ class OpenAIAgent(BaseAgent):
 
         basemodel_fixp_completion = cast(ChatCompletion[BaseModel], fixp_completion)
         if self.memory is not None:
-            self.memory.store_memory(messages, basemodel_fixp_completion, workflow_run)
+            self.memory.store_memory(
+                self.id, messages, basemodel_fixp_completion, workflow_run
+            )
         self._trigger_completion_callbacks(messages, basemodel_fixp_completion)
         return fixp_completion
 

--- a/src/fixpoint/agents/protocol.py
+++ b/src/fixpoint/agents/protocol.py
@@ -31,6 +31,7 @@ T_contra = TypeVar("T_contra", bound=BaseModel, contravariant=True)
 class BaseAgent(Protocol):
     """The base protocol for agents"""
 
+    id: str
     memory: SupportsMemory
 
     # We create overloaded versions of the `create_completion` method so that we

--- a/src/fixpoint/analyze/memory.py
+++ b/src/fixpoint/analyze/memory.py
@@ -54,7 +54,7 @@ class DataframeMemory(Memory):
         for idx, memitem in enumerate(self.memories()):
             messages = memitem.messages
             completion = memitem.completion
-            workflow_run_id = memitem.workflow_run.id if memitem.workflow_run else None
+            workflow_run_id = memitem.workflow_run_id
             for message in messages:
                 data["turn_id"].append(idx)
                 data["role"].append(message["role"])

--- a/src/fixpoint/cache/__init__.py
+++ b/src/fixpoint/cache/__init__.py
@@ -8,15 +8,17 @@ from .protocol import (
     CreateChatCompletionRequest,
 )
 from ._shared import parse_create_chat_completion_request
+from .tlru import TLRUCacheItem
 from .chattlru import ChatCompletionTLRUCache, ChatCompletionTLRUCacheItem
 from .disktlru import ChatCompletionDiskTLRUCache
 
 __all__ = [
-    "SupportsCache",
+    "ChatCompletionDiskTLRUCache",
     "ChatCompletionTLRUCache",
     "ChatCompletionTLRUCacheItem",
-    "ChatCompletionDiskTLRUCache",
-    "SupportsChatCompletionCache",
     "CreateChatCompletionRequest",
     "parse_create_chat_completion_request",
+    "SupportsCache",
+    "SupportsChatCompletionCache",
+    "TLRUCacheItem",
 ]

--- a/src/fixpoint/memory/_memory.py
+++ b/src/fixpoint/memory/_memory.py
@@ -1,7 +1,8 @@
 """Code for agent memory"""
 
-from typing import List, Protocol, Optional, Any, Callable
 import json
+from typing import List, Protocol, Optional, Any, Callable
+import uuid
 
 from pydantic import BaseModel
 
@@ -10,43 +11,84 @@ from ..workflows import SupportsWorkflowRun
 from ..storage.protocol import SupportsStorage
 
 
+def new_memory_item_id() -> str:
+    """Generate a new memory item ID"""
+    return "amem-" + str(uuid.uuid4())
+
+
 class MemoryItem:
     """A single memory item"""
 
+    # The ID field is useful when identifying this resource in storage, or in a
+    # future HTTP-API
+    id: str
+    agent_id: str
     messages: List[ChatCompletionMessageParam]
     completion: ChatCompletion[BaseModel]
-    workflow_run: Optional[SupportsWorkflowRun] = None
+    workflow_id: Optional[str] = None
+    workflow_run_id: Optional[str] = None
 
     def __init__(
         self,
+        agent_id: str,
         messages: List[ChatCompletionMessageParam],
         completion: ChatCompletion[BaseModel],
         workflow_run: Optional[SupportsWorkflowRun] = None,
+        workflow_id: Optional[str] = None,
+        workflow_run_id: Optional[str] = None,
         serialize_fn: Callable[[Any], str] = json.dumps,
         deserialize_fn: Callable[[str], Any] = json.loads,
+        _id: Optional[str] = None,
     ) -> None:
+        """
+        In general, you should not pass in an ID, but it exists on the init
+        function for deserializing from storage.
+        """
+        if workflow_run and (workflow_id or workflow_run_id):
+            raise ValueError(
+                'you cannot pass "workflow_run" alongside "workflow_id" or "workflow_run_id"'
+            )
+
+        self.id = _id or new_memory_item_id()
+        self.agent_id = agent_id
         self.messages = messages
         self.completion = completion
-        self.workflow_run = workflow_run
+
+        if workflow_run:
+            self.workflow_id = workflow_run.workflow_id
+            self.workflow_run_id = workflow_run.id
+        else:
+            self.workflow_id = workflow_id
+            self.workflow_run_id = workflow_run_id
+
         self._serialize_fn = serialize_fn
         self._deserialize_fn = deserialize_fn
 
     def serialize(self) -> dict[str, Any]:
         """Convert the item to a dictionary"""
         return {
+            "id": self.id,
+            "agent_id": self.agent_id,
             "messages": self._serialize_fn(self.messages),
             "completion": self.completion.serialize_json(),
-            "workflow_run": self._serialize_fn(self.workflow_run),
+            "workflow_id": self.workflow_id,
+            "workflow_run_id": self.workflow_run_id,
         }
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> "MemoryItem":
         """Deserialize a dictionary into a TLRUCacheItem"""
 
-        messages = json.loads(data.pop("messages"))
-        completion = ChatCompletion[BaseModel].deserialize_json(data.pop("completion"))
-        workflow_run = json.loads(data.pop("workflow_run"))
-        return cls(messages=messages, completion=completion, workflow_run=workflow_run)
+        return cls(
+            _id=data.pop("id"),
+            agent_id=data.pop("agent_id"),
+            messages=json.loads(data.pop("messages")),
+            completion=ChatCompletion[BaseModel].deserialize_json(
+                data.pop("completion")
+            ),
+            workflow_id=data.pop("workflow_id"),
+            workflow_run_id=data.pop("workflow_run_id"),
+        )
 
 
 class SupportsMemory(Protocol):
@@ -57,6 +99,7 @@ class SupportsMemory(Protocol):
 
     def store_memory(
         self,
+        agent_id: str,
         messages: List[ChatCompletionMessageParam],
         completion: ChatCompletion[BaseModel],
         workflow_run: Optional[SupportsWorkflowRun] = None,
@@ -79,6 +122,7 @@ class Memory(SupportsMemory):
 
     def store_memory(
         self,
+        agent_id: str,
         messages: List[ChatCompletionMessageParam],
         completion: ChatCompletion[BaseModel],
         workflow_run: Optional[SupportsWorkflowRun] = None,
@@ -90,7 +134,10 @@ class Memory(SupportsMemory):
             completion (Optional[ChatCompletion]): The completion object, if any.
         """
         mem_item = MemoryItem(
-            messages=messages, completion=completion, workflow_run=workflow_run
+            agent_id=agent_id,
+            messages=messages,
+            completion=completion,
+            workflow_run=workflow_run,
         )
         self._memory.append(mem_item)
         if self._storage is not None:

--- a/src/fixpoint/memory/_no_op_memory.py
+++ b/src/fixpoint/memory/_no_op_memory.py
@@ -18,6 +18,7 @@ class NoOpMemory(SupportsMemory):
 
     def store_memory(
         self,
+        agent_id: str,
         messages: List[ChatCompletionMessageParam],
         completion: ChatCompletion[BaseModel],
         workflow_run: Optional[SupportsWorkflowRun] = None,

--- a/src/fixpoint_extras/services/formagent/setup.py
+++ b/src/fixpoint_extras/services/formagent/setup.py
@@ -26,6 +26,7 @@ def setup_workflow(
     # Log token usage
     tokenlogger = TikTokenLogger(model_name)
     agent = fixpoint.agents.OpenAIAgent(
+        agent_id="main",
         model_name=model_name,
         openai_clients=OpenAIClients.from_api_key(
             openai_key, base_url=openai_base_url, default_headers=default_openai_headers
@@ -37,4 +38,4 @@ def setup_workflow(
 
     workflow_run = Workflow(id="form_filler_agent").run()
 
-    return WorkflowContext.from_workflow(workflow_run, {"main": agent}, cache)
+    return WorkflowContext.from_workflow(workflow_run, [agent], cache)

--- a/src/fixpoint_extras/workflows/imperative/_workflow_agent.py
+++ b/src/fixpoint_extras/workflows/imperative/_workflow_agent.py
@@ -38,6 +38,16 @@ class WorkflowAgent(BaseAgent):
         """Set the memory container for the agent"""
         raise ValueError("memory cannot be set. It is inferred from the workflow")
 
+    @property
+    def id(self) -> str:
+        """Get the agent id"""
+        return self._inner_agent.id
+
+    @id.setter
+    def id(self, _agent_id: str) -> None:
+        """Set the agent id"""
+        raise ValueError("agent_id cannot be set once already inside a workflow")
+
     @overload
     def create_completion(
         self,

--- a/src/fixpoint_extras/workflows/imperative/config.py
+++ b/src/fixpoint_extras/workflows/imperative/config.py
@@ -1,0 +1,209 @@
+"""Configuration for imperative workflows
+
+Configuration for imperative workflows, such as setting up storage.
+"""
+
+from typing import Callable, List, Optional
+
+from pydantic import BaseModel
+
+from fixpoint import cache, memory, storage
+from .document import Document
+from .form import Form
+
+_DEF_CHAT_CACHE_MAX_SIZE = 50000
+_DEF_CHAT_CACHE_TTL_S = 60 * 60 * 24 * 7
+
+
+class StorageConfig:
+    """Storage configuration for imperative workflows and its agents, etc."""
+
+    forms_storage: Optional[storage.SupportsStorage[Form[BaseModel]]]
+    docs_storage: Optional[storage.SupportsStorage[Document]]
+    agent_cache: Optional[cache.SupportsChatCompletionCache]
+    memory_factory: Callable[[str], memory.SupportsMemory]
+
+    def __init__(
+        self,
+        forms_storage: Optional[storage.SupportsStorage[Form[BaseModel]]],
+        docs_storage: Optional[storage.SupportsStorage[Document]],
+        agent_cache: Optional[cache.SupportsChatCompletionCache],
+        memory_factory: Callable[[str], memory.SupportsMemory],
+    ):
+        self.forms_storage = forms_storage
+        self.docs_storage = docs_storage
+        self.agent_cache = agent_cache
+        self.memory_factory = memory_factory
+
+    @classmethod
+    def with_defaults(
+        cls,
+        chat_cache_maxsize: int = _DEF_CHAT_CACHE_MAX_SIZE,
+        chat_cache_ttl_s: int = _DEF_CHAT_CACHE_TTL_S,
+    ) -> "StorageConfig":
+        """Configure default storage"""
+        return cls.with_in_memory(chat_cache_maxsize, chat_cache_ttl_s)
+
+    @classmethod
+    def with_supabase(
+        cls,
+        supabase_url: str,
+        supabase_api_key: str,
+        chat_cache_maxsize: int = _DEF_CHAT_CACHE_MAX_SIZE,
+        chat_cache_ttl_s: int = _DEF_CHAT_CACHE_TTL_S,
+    ) -> "StorageConfig":
+        """Configure supabase storage"""
+        forms_storage = create_form_supabase_storage(supabase_url, supabase_api_key)
+        docs_storage = create_docs_supabase_storage(supabase_url, supabase_api_key)
+        agent_cache = cache.ChatCompletionTLRUCache(
+            maxsize=chat_cache_maxsize,
+            ttl_s=chat_cache_ttl_s,
+            storage=create_chat_completion_cache_supabase_storage(
+                supabase_url, supabase_api_key
+            ),
+        )
+
+        def memory_factory(agent_id: str) -> memory.SupportsMemory:
+            """create memory collections per agent"""
+            return memory.Memory(
+                storage=create_memory_supabase_storage(
+                    supabase_url, supabase_api_key, agent_id
+                ),
+            )
+
+        return cls(
+            forms_storage=forms_storage,
+            docs_storage=docs_storage,
+            agent_cache=agent_cache,
+            memory_factory=memory_factory,
+        )
+
+    @classmethod
+    def with_disk(cls) -> "StorageConfig":
+        """Configure disk storage"""
+        raise NotImplementedError()
+
+    @classmethod
+    def with_in_memory(
+        cls,
+        chat_cache_maxsize: int = _DEF_CHAT_CACHE_MAX_SIZE,
+        chat_cache_ttl_s: int = _DEF_CHAT_CACHE_TTL_S,
+    ) -> "StorageConfig":
+        """Configure in-memory storage"""
+
+        def memory_factory(_agent_id: str) -> memory.SupportsMemory:
+            """create memory collections per agent"""
+            return memory.Memory()
+
+        agent_cache = cache.ChatCompletionTLRUCache(
+            maxsize=chat_cache_maxsize,
+            ttl_s=chat_cache_ttl_s,
+        )
+
+        return cls(
+            forms_storage=None,
+            docs_storage=None,
+            agent_cache=agent_cache,
+            memory_factory=memory_factory,
+        )
+
+
+_def_storage: List[Optional[StorageConfig]] = [None]
+
+
+def get_default_storage_config() -> StorageConfig:
+    """Gets the default storage config singleton"""
+    if _def_storage[0] is None:
+        storage_cfg = StorageConfig.with_defaults(
+            chat_cache_maxsize=_DEF_CHAT_CACHE_MAX_SIZE,
+            chat_cache_ttl_s=_DEF_CHAT_CACHE_TTL_S,
+        )
+        _def_storage[0] = storage_cfg
+        return storage_cfg
+    else:
+        return _def_storage[0]
+
+
+def create_form_supabase_storage(
+    supabase_url: str, supabase_api_key: str
+) -> storage.SupabaseStorage[Form[BaseModel]]:
+    """Create a supabase storage driver for forms"""
+    return storage.SupabaseStorage[Form[BaseModel]](
+        url=supabase_url,
+        key=supabase_api_key,
+        table="forms_with_metadata",
+        order_key="id",
+        id_column="id",
+        value_type=Form[BaseModel],
+    )
+
+
+def create_docs_supabase_storage(
+    supabase_url: str, supabase_api_key: str
+) -> storage.SupabaseStorage[Document]:
+    """Create a supabase storage driver for documents"""
+    return storage.SupabaseStorage[Document](
+        url=supabase_url,
+        key=supabase_api_key,
+        table="documents",
+        order_key="id",
+        id_column="id",
+        value_type=Document,
+    )
+
+
+def create_chat_completion_cache_supabase_storage(
+    supabase_url: str, supabase_api_key: str
+) -> storage.SupabaseStorage[cache.ChatCompletionTLRUCacheItem[BaseModel]]:
+    """Create a supabase storage driver for chat completion caching"""
+    return storage.SupabaseStorage(
+        url=supabase_url,
+        key=supabase_api_key,
+        table="completion_cache",
+        order_key="expires_at",
+        id_column="key",
+        # We cannot not specify the generic type parameter for
+        # TLRUCacheItem, because then when we try to do `isinstance(cls,
+        # type)`, the class will actually be a `typing.GenericAlias` and not
+        # a type (class definition).
+        value_type=cache.ChatCompletionTLRUCacheItem,
+    )
+
+
+def create_str_cache_supabase_storage(
+    supabase_url: str, supabase_api_key: str
+) -> storage.SupabaseStorage[cache.TLRUCacheItem[str]]:
+    """Create a supabase storage driver for chat completion caching"""
+    return storage.SupabaseStorage(
+        url=supabase_url,
+        key=supabase_api_key,
+        table="completion_cache",
+        order_key="expires_at",
+        id_column="key",
+        value_type=cache.TLRUCacheItem[str],
+    )
+
+
+def create_memory_supabase_storage(
+    supabase_url: str,
+    supabase_api_key: str,
+    agent_id: str,  # pylint: disable=unused-argument
+) -> storage.SupabaseStorage[memory.MemoryItem]:
+    """Create a supabase storage driver for agent memories"""
+    # TODO(dbmikus) we need to make use of the agent_id
+    # We put a id on the agent itself, so do we need an agent_id on the memory?
+    # We can either attach agent IDs to the agents or to the memory, or perhaps
+    # to both.
+
+    return storage.SupabaseStorage[memory.MemoryItem](
+        url=supabase_url,
+        key=supabase_api_key,
+        table="memory_store",
+        # TODO(dbmikus) what should we do about composite ID columns?
+        # Personally, I think we should not use the generic SupabaseStorage
+        # class for storing agent memories, and instead pass in an interface
+        # that is resource-oriented around these memories
+        order_key="agent_id",
+        id_column="id",
+        value_type=memory.MemoryItem,
+    )

--- a/src/fixpoint_extras/workflows/structured/_workflow.py
+++ b/src/fixpoint_extras/workflows/structured/_workflow.py
@@ -136,7 +136,7 @@ class WorkflowInstanceFixp:
 def _default_ctx_factory(run: WorkflowRun) -> WorkflowContext:
     return WorkflowContext.from_workflow(
         workflow_run=run,
-        agents={},
+        agents=[],
         # TODO(dbmikus) change default to an in-memory cache
         cache=fixpoint.cache.ChatCompletionDiskTLRUCache.from_tmpdir(
             # 1 hour

--- a/tests/agents/oai/openai_test.py
+++ b/tests/agents/oai/openai_test.py
@@ -3,11 +3,9 @@ from unittest.mock import patch
 
 import pytest
 from openai.types.chat.chat_completion import (
-    Choice as CompletionChoice,
     ChatCompletion as OpenAIChatCompletion,
 )
 
-import fixpoint
 from fixpoint.agents.oai import OpenAI
 from fixpoint.agents.openai import OpenAIClients
 from fixpoint._utils.completions import decorate_instructor_completion_with_fixp
@@ -19,14 +17,15 @@ class TestAgents:
     def test_openai_agent_bad_model_instantiation(self) -> None:
         # Check that if an invalid model is passed in then a ValueError is raised
         with pytest.raises(ValueError):
-            OpenAI("bad-model", OpenAIClients.from_api_key("api-key"))
+            OpenAI("agent-id-1", "bad-model", OpenAIClients.from_api_key("api-key"))
         # Check that if None is passed in then a ValueError is raised
         with pytest.raises(ValueError):
-            OpenAI(None, OpenAIClients.from_api_key("api-key"))  # type: ignore
+            OpenAI("agent-id-2", None, OpenAIClients.from_api_key("api-key"))  # type: ignore
 
     def test_openai_agent_valid_model_instantiation(self) -> None:
         # Instantiate an agent
         agent = OpenAI(
+            agent_id="agent-id-1",
             model_name="gpt-3.5-turbo",
             openai_clients=OpenAIClients.from_api_key("api-key"),
         )
@@ -40,6 +39,7 @@ class TestAgents:
     def test_openai_agent_completions_proxy(self) -> None:
         # Instantiate an agent
         agent = OpenAI(
+            agent_id="agent-id-1",
             model_name="gpt-3.5-turbo",
             openai_clients=OpenAIClients.from_api_key("api-key"),
         )

--- a/tests/extras/workflows/imperative/test_documents.py
+++ b/tests/extras/workflows/imperative/test_documents.py
@@ -1,9 +1,8 @@
 from typing import List, Tuple
 import pytest
-from fixpoint.storage.supabase import SupabaseStorage
 from fixpoint_extras.workflows.imperative.workflow import Workflow
-from fixpoint_extras.workflows.imperative.form import Form
 from fixpoint_extras.workflows.imperative.document import Document
+from fixpoint_extras.workflows.imperative.config import create_docs_supabase_storage
 
 from tests.supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
@@ -74,9 +73,11 @@ class TestDocuments:
                 f"""
         CREATE TABLE IF NOT EXISTS public.documents (
             id text PRIMARY KEY,
-            path text,
-            metadata jsonb,
-            contents text
+            workflow_id text,
+            workflow_run_id text,
+            path text NOT NULL,
+            metadata jsonb NOT NULL,
+            contents text NOT NULL
         );
 
         TRUNCATE TABLE public.documents
@@ -90,15 +91,7 @@ class TestDocuments:
         self, supabase_setup_url_and_key: Tuple[str, str]
     ) -> None:
         url, key = supabase_setup_url_and_key
-
-        document_storage = SupabaseStorage(
-            url,
-            key,
-            table="documents",
-            order_key="id",
-            id_column="id",
-            value_type=Document,
-        )
+        document_storage = create_docs_supabase_storage(url, key)
 
         workflow = Workflow(
             id="test_workflow",

--- a/tests/extras/workflows/imperative/test_forms.py
+++ b/tests/extras/workflows/imperative/test_forms.py
@@ -3,9 +3,9 @@ import json
 import pytest
 from pydantic import BaseModel, Field
 
-from fixpoint.storage.supabase import SupabaseStorage
 from fixpoint_extras.workflows.imperative.workflow import Workflow
 from fixpoint_extras.workflows.imperative.form import Form, _is_valid_field_annotation
+from fixpoint_extras.workflows.imperative.config import create_form_supabase_storage
 
 from tests.supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
 
@@ -213,14 +213,15 @@ class TestForms:
                 f"""
         CREATE TABLE IF NOT EXISTS public.forms_with_metadata (
             id text PRIMARY KEY,
+            workflow_id text,
             workflow_run_id text,
             metadata jsonb,
-            path text,
-            contents jsonb,
-            form_schema text,
+            path text NOT NULL,
+            contents jsonb NOT NULL,
+            form_schema text NOT NULL,
             versions jsonb,
-            step text,
-            task text
+            task text,
+            step text
         );
 
         TRUNCATE TABLE public.forms_with_metadata
@@ -235,14 +236,7 @@ class TestForms:
     ) -> None:
         url, key = supabase_setup_url_and_key
 
-        form_storage = SupabaseStorage(
-            url,
-            key,
-            table="forms_with_metadata",
-            order_key="id",
-            id_column="id",
-            value_type=Form[TicketOrderForm],
-        )
+        form_storage = create_form_supabase_storage(url, key)
 
         workflow = Workflow(
             id="test_workflow",

--- a/tests/extras/workflows/structured/test_step.py
+++ b/tests/extras/workflows/structured/test_step.py
@@ -49,6 +49,6 @@ def new_workflow_context(workflow_id: str) -> structured.WorkflowContext:
     wrun = workflow.run()
     ctx = structured.WorkflowContext.from_workflow(
         wrun,
-        agents={},
+        agents=[],
     )
     return ctx

--- a/tests/extras/workflows/structured/test_task.py
+++ b/tests/extras/workflows/structured/test_task.py
@@ -61,7 +61,7 @@ async def test_call_task() -> None:
     wrun = workflow.run()
     ctx = structured.WorkflowContext.from_workflow(
         wrun,
-        agents={},
+        agents=[],
     )
     res = await structured.call_task(ctx, MyTask.run, args=["Dylan"])
     assert res == "Hello, Dylan"


### PR DESCRIPTION
Set up factories for configuring all necessary storage for workflows. This includes:

- form storage
- document storage
- agent memory
- agent cache

Also, create a Postgres migration file that configures the appropriate tables. I took the example tables from within the tests, but I made some changes to them. Generally, I made some columns non-nullable, added workflow info to a few tables, and made the memory table support multiple agents. I also updated tests so that the adhoc postgres table creations use the new table formats.

As part of making memory work for multiple agents, we need each agent to have a ID.

Originally, you could specify a ID when creating an agent, and if you don't it will be given a random ID. When you created a structured workflow, you pass in a dictionary of agent IDs to agents, and we can set the agent IDs based on that, if they were originally randomly set. That had some complications though: what if the dictionary of agents had keys that didn't match up with the agent IDs on the agent objects? Should we keep the different IDs or reconcile them? If we reconcile them, will we be modifying the underlying agent object's IDs? It seemed confusing.

So, instead we require every agent to be given an ID manually, and when you create a `WorkflowContext`, you pass in a list of agents. Each of these agents has an ID, so we can build a dictionary mapping agent IDs to the respective agents.