### PR TITLE
[structured] Extend WorkflowRunHandle functionality

### DIFF
--- a/src/fixpoint_extras/workflows/imperative/workflow.py
+++ b/src/fixpoint_extras/workflows/imperative/workflow.py
@@ -179,7 +179,6 @@ class _Documents:
 
     def get(
         self,
-        *,
         document_id: str,
     ) -> Union[Document, None]:
         """Get a document from the cache.
@@ -196,10 +195,10 @@ class _Documents:
     def store(
         self,
         *,
+        id: str,
         contents: str,
         metadata: Optional[dict[str, Any]] = None,
         # pylint: disable=redefined-builtin
-        id: str,
         path: Optional[str] = None,
     ) -> Document:
         """Store a document in the cache.
@@ -296,7 +295,7 @@ class _Forms:
         self._storage = storage
         self._memory: Dict[str, Form[BaseModel]] = {}
 
-    def get(self, *, form_id: str) -> Union[Form[BaseModel], None]:
+    def get(self, form_id: str) -> Union[Form[BaseModel], None]:
         """Get a form from the cache.
 
         Gets the latest version of the form.

--- a/src/fixpoint_extras/workflows/structured/_workflow.py
+++ b/src/fixpoint_extras/workflows/structured/_workflow.py
@@ -27,7 +27,7 @@ import fixpoint
 from .. import imperative
 from .errors import DefinitionException, InternalException
 from ._context import WorkflowContext
-from ._helpers import validate_func_has_context_arg, Params, Ret, Ret_co
+from ._helpers import validate_func_has_context_arg, AsyncFunc, Params, Ret, Ret_co
 from ._run_config import RunConfig
 from ._workflow_run_handle import WorkflowRunHandle, WorkflowRunHandleImpl
 
@@ -183,7 +183,7 @@ class WorkflowEntryFixp:
     workflow_cls: Optional[Type[Any]] = None
 
 
-def workflow_entrypoint() -> Callable[[Callable[Params, Ret]], Callable[Params, Ret]]:
+def workflow_entrypoint() -> Callable[[AsyncFunc[Params, Ret]], AsyncFunc[Params, Ret]]:
     """Mark the entrypoint function of a workflow class definition
 
     When you have a workflow class definition, you must have exactly one class
@@ -252,7 +252,7 @@ def get_workflow_instance_fixp(instance: C) -> Optional[WorkflowInstanceFixp]:
 
 
 def spawn_workflow(
-    workflow_entry: Callable[Params, Ret_co],
+    workflow_entry: AsyncFunc[Params, Ret_co],
     *,
     run_config: RunConfig,
     agents: List[fixpoint.agents.BaseAgent],
@@ -331,8 +331,8 @@ def spawn_workflow(
     return WorkflowRunHandleImpl[Ret_co](fixp.run_fixp.workflow_run, res)
 
 
-def run_workflow(
-    workflow_entry: Callable[Params, Ret_co],
+async def run_workflow(
+    workflow_entry: AsyncFunc[Params, Ret_co],
     *,
     run_config: RunConfig,
     agents: List[fixpoint.agents.BaseAgent],
@@ -347,4 +347,4 @@ def run_workflow(
     wrun_handle = spawn_workflow(
         workflow_entry, run_config=run_config, agents=agents, args=args, kwargs=kwargs
     )
-    return wrun_handle.result()
+    return await wrun_handle.result()

--- a/src/fixpoint_extras/workflows/structured/_workflow_run_handle.py
+++ b/src/fixpoint_extras/workflows/structured/_workflow_run_handle.py
@@ -4,16 +4,18 @@ A handle on a WorkflowRun, which is used to check the status of a workflow run,
 access its result, etc.
 """
 
-from typing import Protocol
+from typing import Any, Coroutine, Optional, Protocol, cast
 
 from .. import imperative
 from ._helpers import Ret_co
+
+Coro = Coroutine[Any, Any, Ret_co]
 
 
 class WorkflowRunHandle(Protocol[Ret_co]):
     """A handle on a running workflow"""
 
-    def result(self) -> Ret_co:
+    async def result(self) -> Ret_co:
         """The result of running a workflow"""
 
     def workflow_id(self) -> str:
@@ -22,22 +24,71 @@ class WorkflowRunHandle(Protocol[Ret_co]):
     def workflow_run_id(self) -> str:
         """The ID of the workflow run"""
 
+    def finalized_workflow_run(self) -> Optional[imperative.WorkflowRun]:
+        """Get the workflow run, but only after we have finished the async workflow
+
+        This workflow run is returned as an awaitable that only resolves once
+        the workflow has finished running. For the safety of the workflow, we
+        don't want code outside a running workflow to have access to the
+        WorkflowRun object until the workflow run is finished.
+        """
+
+    def is_open(self) -> bool:
+        """Whether the workflow is running, or open but waiting before resuming.
+
+        A workflow is open when it is actively running, or if it is suspended
+        while waiting for some other event, such as a human-in-the-loop review.
+        """
+
+    def is_closed(self) -> bool:
+        """Whether the workflow is closed (aka not open).
+
+        A workflow is closed when it either succeeds, errors out, is cancelled,
+        or otherwise stops.
+        """
+
 
 class WorkflowRunHandleImpl(WorkflowRunHandle[Ret_co]):
     """Handle to a workflow run."""
 
     _workflow_run: imperative.WorkflowRun
-    _result: Ret_co
+    _result: Coroutine[Any, Any, Ret_co]
+    _awaited_result: Optional[Ret_co]
+    _was_awaited: bool
+    _is_open: bool
 
-    def __init__(self, workflow_run: imperative.WorkflowRun, result: Ret_co) -> None:
+    def __init__(
+        self, workflow_run: imperative.WorkflowRun, result: Coroutine[Any, Any, Ret_co]
+    ) -> None:
         self._workflow_run = workflow_run
         self._result = result
+        self._awaited_result = None
+        self._was_awaited = False
+        self._is_open = True
 
-    def result(self) -> Ret_co:
-        return self._result
+    async def result(self) -> Ret_co:
+        if self._was_awaited:
+            return cast(Ret_co, self._awaited_result)
+        try:
+            self._awaited_result = await self._result
+        finally:
+            self._was_awaited = True
+            self._is_open = False
+        return self._awaited_result
 
     def workflow_id(self) -> str:
         return self._workflow_run.workflow_id
 
     def workflow_run_id(self) -> str:
         return self._workflow_run.id
+
+    def finalized_workflow_run(self) -> Optional[imperative.WorkflowRun]:
+        if self.is_closed():
+            return self._workflow_run
+        return None
+
+    def is_open(self) -> bool:
+        return self._is_open
+
+    def is_closed(self) -> bool:
+        return not self.is_open()

--- a/tests/extras/workflows/structured/test_workflow.py
+++ b/tests/extras/workflows/structured/test_workflow.py
@@ -22,11 +22,11 @@ def test_workflow_declaration() -> None:
         @structured.workflow(id="two_main_tasks")
         class TwoMainTasks:
             @structured.workflow_entrypoint()
-            def main(self, _ctx: structured.WorkflowContext) -> None:
+            async def main(self, _ctx: structured.WorkflowContext) -> None:
                 pass
 
             @structured.workflow_entrypoint()
-            def other_main(self, _ctx: structured.WorkflowContext) -> None:
+            async def other_main(self, _ctx: structured.WorkflowContext) -> None:
                 pass
 
 
@@ -36,7 +36,7 @@ def test_at_least_ctx_arg() -> None:
         @structured.workflow(id="workflow_without_main_task")
         class WorkflowWithoutMainTask:
             @structured.workflow_entrypoint()
-            def main(self) -> None:
+            async def main(self) -> None:
                 pass
 
 
@@ -44,7 +44,7 @@ def test_valid_workflow() -> None:
     @structured.workflow(id="valid_workflow")
     class ValidWorkflow:
         @structured.workflow_entrypoint()
-        def main(self, ctx: structured.WorkflowContext) -> None:
+        async def main(self, ctx: structured.WorkflowContext) -> None:
             pass
 
 


### PR DESCRIPTION
Extend the `WorkflowRunHandle` with methods to check the status of the workflow (open/closed) and to get the inner `WorkflowRun` object via `WorkflowRunHandle.finalized_workflow_run(...)`.
`finalized_workflow_run` will only return a `WorkflowRun` if we finished awaiting the coroutine result of the workflow.

Also, squeeze in a little more code into the `examples/structured_workflow.py` file that shows how we can save/load the chat completion results to a dataframe.