### PR TITLE
Add on-disk caching for structured workflows

### DIFF
--- a/src/fixpoint/_constants.py
+++ b/src/fixpoint/_constants.py
@@ -1,4 +1,6 @@
 """Constants for the "fixpoint" package"""
 
+__all__ = ["DEFAULT_DISK_CACHE_SIZE_LIMIT_BYTES"]
+
 # 50 MB
 DEFAULT_DISK_CACHE_SIZE_LIMIT_BYTES = 50 * 1024 * 1024

--- a/src/fixpoint/workflows/structured/_callcache/__init__.py
+++ b/src/fixpoint/workflows/structured/_callcache/__init__.py
@@ -7,7 +7,10 @@ __all__ = [
     "CacheResult",
     "StepInMemCallCache",
     "TaskInMemCallCache",
+    "StepDiskCallCache",
+    "TaskDiskCallCache",
 ]
 
 from ._shared import CallCache, CallCacheKind, CacheResult, serialize_args
 from ._in_mem import StepInMemCallCache, TaskInMemCallCache
+from ._disk import StepDiskCallCache, TaskDiskCallCache

--- a/src/fixpoint/workflows/structured/_callcache/_disk.py
+++ b/src/fixpoint/workflows/structured/_callcache/_disk.py
@@ -60,6 +60,16 @@ class StepDiskCallCache(CallCache):
         serialized_args: str,
         type_hint: Optional[Type[Any]] = None,
     ) -> CacheResult[T]:
+        """Get the cached result, if it exists.
+
+        Check the cache for the cached result for the given run, task/step, and
+        arguments. If it exists, return the cached result. Otherwise, return
+        None.
+
+        If you provide a `type_hint`, we will load the cached result into that
+        type. We can load in Pydantic models and dataclasses.
+        """
+
         key = serialize_step_cache_key(
             run_id=run_id, step_id=kind_id, args=serialized_args
         )
@@ -74,6 +84,7 @@ class StepDiskCallCache(CallCache):
     def store_result(
         self, run_id: str, kind_id: str, serialized_args: str, res: Any
     ) -> None:
+        """Stores the results of a task or step into the call cache."""
         key = serialize_step_cache_key(
             run_id=run_id, step_id=kind_id, args=serialized_args
         )

--- a/src/fixpoint/workflows/structured/_callcache/_disk.py
+++ b/src/fixpoint/workflows/structured/_callcache/_disk.py
@@ -32,14 +32,14 @@ class StepDiskCallCache(CallCache):
 
     cache_kind = CallCacheKind.STEP
     _ttl_s: Optional[float]
+    _cache: diskcache.Cache
 
     def __init__(
         self,
-        cache_dir: str,
+        cache: diskcache.Cache,
         ttl_s: Optional[float] = None,
-        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
     ) -> None:
-        self._cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        self._cache = cache
         self._ttl_s = ttl_s
 
     @classmethod
@@ -50,7 +50,8 @@ class StepDiskCallCache(CallCache):
     ) -> "StepDiskCallCache":
         """Create a new cache from inside a temporary directory"""
         cache_dir = tempfile.mkdtemp()
-        return cls(cache_dir, ttl_s, size_limit_bytes)
+        cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        return cls(cache, ttl_s)
 
     def check_cache(
         self,
@@ -85,14 +86,14 @@ class TaskDiskCallCache(CallCache):
     """An on-disk call-cache for tasks"""
 
     cache_kind = CallCacheKind.TASK
+    _cache: diskcache.Cache
 
     def __init__(
         self,
-        cache_dir: str,
+        cache: diskcache.Cache,
         ttl_s: Optional[float] = None,
-        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
     ) -> None:
-        self._cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        self._cache = cache
         self._ttl_s = ttl_s
 
     @classmethod
@@ -103,7 +104,8 @@ class TaskDiskCallCache(CallCache):
     ) -> "TaskDiskCallCache":
         """Create a new cache from inside a temporary directory"""
         cache_dir = tempfile.mkdtemp()
-        return cls(cache_dir, ttl_s, size_limit_bytes)
+        cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        return cls(cache, ttl_s)
 
     def check_cache(
         self,

--- a/src/fixpoint/workflows/structured/_callcache/_disk.py
+++ b/src/fixpoint/workflows/structured/_callcache/_disk.py
@@ -1,0 +1,115 @@
+"""Call cache that stores to disk"""
+
+import tempfile
+from typing import Any, Optional
+
+import diskcache
+
+from fixpoint._constants import (
+    DEFAULT_DISK_CACHE_SIZE_LIMIT_BYTES as DEFAULT_SIZE_LIMIT_BYTES,
+)
+from ._shared import (
+    CallCache,
+    CallCacheKind,
+    CacheResult,
+    serialize_step_cache_key,
+    serialize_task_cache_key,
+    default_json_dumps,
+    T,
+    logger,
+)
+
+
+class StepDiskCallCache(CallCache):
+    """An on-disk call-cache for steps"""
+
+    cache_kind = CallCacheKind.STEP
+    _ttl_s: Optional[float]
+
+    def __init__(
+        self,
+        cache_dir: str,
+        ttl_s: Optional[float] = None,
+        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
+    ) -> None:
+        self._cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        self._ttl_s = ttl_s
+
+    @classmethod
+    def from_tmpdir(
+        cls,
+        ttl_s: Optional[float] = None,
+        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
+    ) -> "StepDiskCallCache":
+        """Create a new cache from inside a temporary directory"""
+        cache_dir = tempfile.mkdtemp()
+        return cls(cache_dir, ttl_s, size_limit_bytes)
+
+    def check_cache(
+        self, run_id: str, kind_id: str, serialized_args: str
+    ) -> CacheResult[T]:
+        key = serialize_step_cache_key(
+            run_id=run_id, step_id=kind_id, args=serialized_args
+        )
+        if key in self._cache:
+            logger.debug(f"Cache hit for step {kind_id} with key {key}")
+            return CacheResult[T](found=True, result=self._cache[key])
+        logger.debug(f"Cache miss for step {kind_id} with key {key}")
+        return CacheResult[T](found=False, result=None)
+
+    def store_result(
+        self, run_id: str, kind_id: str, serialized_args: str, res: Any
+    ) -> None:
+        key = serialize_step_cache_key(
+            run_id=run_id, step_id=kind_id, args=serialized_args
+        )
+        res_serialized = default_json_dumps(res)
+        self._cache.set(key, res_serialized, expire=self._ttl_s)
+        logger.debug(f"Stored result for step {kind_id} with key {key}")
+
+
+class TaskDiskCallCache(CallCache):
+    """An on-disk call-cache for tasks"""
+
+    cache_kind = CallCacheKind.TASK
+
+    def __init__(
+        self,
+        cache_dir: str,
+        ttl_s: Optional[float] = None,
+        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
+    ) -> None:
+        self._cache = diskcache.Cache(directory=cache_dir, size_limit=size_limit_bytes)
+        self._ttl_s = ttl_s
+
+    @classmethod
+    def from_tmpdir(
+        cls,
+        ttl_s: Optional[float] = None,
+        size_limit_bytes: int = DEFAULT_SIZE_LIMIT_BYTES,
+    ) -> "TaskDiskCallCache":
+        """Create a new cache from inside a temporary directory"""
+        cache_dir = tempfile.mkdtemp()
+        return cls(cache_dir, ttl_s, size_limit_bytes)
+
+    def check_cache(
+        self, run_id: str, kind_id: str, serialized_args: str
+    ) -> CacheResult[T]:
+        key = serialize_task_cache_key(
+            run_id=run_id, task_id=kind_id, args=serialized_args
+        )
+        if key in self._cache:
+            logger.debug(f"Cache hit for task {kind_id} with key {key}")
+            return CacheResult[T](found=True, result=self._cache[key])
+        logger.debug(f"Cache miss for task {kind_id} with key {key}")
+        return CacheResult[T](found=False, result=None)
+
+    def store_result(
+        self, run_id: str, kind_id: str, serialized_args: str, res: Any
+    ) -> None:
+        key = serialize_task_cache_key(
+            run_id=run_id, task_id=kind_id, args=serialized_args
+        )
+        res_serialized = default_json_dumps(res)
+        self._cache.set(key, res_serialized, expire=self._ttl_s)
+        logger.debug(f"Stored result for task {kind_id} with key {key}")

--- a/src/fixpoint/workflows/structured/_callcache/_in_mem.py
+++ b/src/fixpoint/workflows/structured/_callcache/_in_mem.py
@@ -2,7 +2,7 @@
 
 __all__ = ["StepInMemCallCache", "TaskInMemCallCache"]
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Type
 
 from ._shared import (
     CallCache,
@@ -24,7 +24,11 @@ class StepInMemCallCache(CallCache):
         self._cache = {}
 
     def check_cache(
-        self, run_id: str, kind_id: str, serialized_args: str
+        self,
+        run_id: str,
+        kind_id: str,
+        serialized_args: str,
+        type_hint: Optional[Type[Any]] = None,
     ) -> CacheResult[T]:
         key = serialize_step_cache_key(
             run_id=run_id, step_id=kind_id, args=serialized_args
@@ -52,7 +56,11 @@ class TaskInMemCallCache(CallCache):
         self._cache = {}
 
     def check_cache(
-        self, run_id: str, kind_id: str, serialized_args: str
+        self,
+        run_id: str,
+        kind_id: str,
+        serialized_args: str,
+        type_hint: Optional[Type[Any]] = None,
     ) -> CacheResult[T]:
         key = serialize_task_cache_key(
             run_id=run_id, task_id=kind_id, args=serialized_args

--- a/src/fixpoint/workflows/structured/_callcache/_in_mem.py
+++ b/src/fixpoint/workflows/structured/_callcache/_in_mem.py
@@ -18,7 +18,6 @@ class StepInMemCallCache(CallCache):
     """An in-memory call-cache for steps"""
 
     cache_kind = CallCacheKind.STEP
-    kind_id: str
     _cache: Dict[str, Any]
 
     def __init__(self) -> None:
@@ -47,7 +46,6 @@ class TaskInMemCallCache(CallCache):
     """An in-memory call-cache for tasks"""
 
     cache_kind = CallCacheKind.TASK
-    kind_id: str
     _cache: Dict[str, Any]
 
     def __init__(self) -> None:

--- a/src/fixpoint/workflows/structured/_callcache/_shared.py
+++ b/src/fixpoint/workflows/structured/_callcache/_shared.py
@@ -16,7 +16,7 @@ import dataclasses
 from dataclasses import is_dataclass
 from enum import Enum
 import json
-from typing import Any, Generic, Optional, Protocol, TypeVar
+from typing import Any, Generic, Optional, Protocol, Type, TypeVar
 
 from pydantic import BaseModel
 
@@ -55,7 +55,11 @@ class CallCache(Protocol):
     cache_kind: CallCacheKind
 
     def check_cache(
-        self, run_id: str, kind_id: str, serialized_args: str
+        self,
+        run_id: str,
+        kind_id: str,
+        serialized_args: str,
+        type_hint: Optional[Type[Any]] = None,
     ) -> CacheResult[Any]:
         """Check if the result of a task or step call is cached"""
 

--- a/src/fixpoint/workflows/structured/_callcache/_shared.py
+++ b/src/fixpoint/workflows/structured/_callcache/_shared.py
@@ -1,22 +1,16 @@
 """Module for caching task and step executions."""
 
 __all__ = [
-    "CallCacheKind",
     "CacheResult",
     "CallCache",
+    "CallCacheKind",
     "JSONEncoder",
+    "logger",
     "serialize_args",
     "serialize_step_cache_key",
     "serialize_task_cache_key",
     "T",
 ]
-
-# TODO(dbmikus) for on-disk or in-DB store, try using dacite or Temporal
-# converter.py[1] for deserialization.
-#
-# The problem is serializing and deserializing dataclasses.
-#
-# [1]: sdk-python/temporalio/converter.py
 
 import dataclasses
 from dataclasses import is_dataclass
@@ -25,6 +19,9 @@ import json
 from typing import Any, Generic, Optional, Protocol, TypeVar
 
 from pydantic import BaseModel
+
+from fixpoint.logging import logger as root_logger
+
 
 T = TypeVar("T")
 
@@ -97,3 +94,6 @@ def serialize_task_cache_key(*, run_id: str, task_id: str, args: str) -> str:
 def default_json_dumps(obj: Any) -> str:
     """Default serialization of an object to JSON"""
     return json.dumps(obj, sort_keys=True, separators=(",", ":"), cls=JSONEncoder)
+
+
+logger = root_logger.getChild("workflows.structured._callcache")

--- a/tests/workflows/structured/_callcache/assertions.py
+++ b/tests/workflows/structured/_callcache/assertions.py
@@ -1,0 +1,49 @@
+from fixpoint.workflows.structured._callcache import (
+    CallCache,
+    serialize_args,
+    CacheResult,
+)
+from .fixtures import DC, DCInner
+
+
+def assert_cache_works(cache: CallCache) -> None:
+    pbm = DC(
+        xyz=DCInner(key200={"x": 99, "a": 50}, key100=100),
+        abc={"x": 2000, "a": 3000},
+        middle=["a", "b", "c"],
+    )
+    serialized = serialize_args(pbm, "something_else", foo="bar")
+
+    res: CacheResult[str] = cache.check_cache(
+        run_id="run-1", kind_id="my-kind", serialized_args=serialized
+    )
+    assert not res.found
+
+    cache.store_result(
+        run_id="run-1", kind_id="my-kind", serialized_args=serialized, res="result0"
+    )
+
+    # recreate the args and see if we get the right result
+    pbm_new = DC(
+        xyz=DCInner(key200={"x": 99, "a": 50}, key100=100),
+        abc={"x": 2000, "a": 3000},
+        middle=["a", "b", "c"],
+    )
+    serialized_new = serialize_args(pbm_new, "something_else", foo="bar")
+    res_new: CacheResult[str] = cache.check_cache(
+        run_id="run-1", kind_id="my-kind", serialized_args=serialized_new
+    )
+    assert res_new.found
+    assert res_new.result == "result0"
+
+    # With a different workflow run, we get a different result
+    res_diff_run: CacheResult[str] = cache.check_cache(
+        run_id="run-2", kind_id="my-kind", serialized_args=serialized_new
+    )
+    assert not res_diff_run.found
+
+    # with a different step/task ID, we get a different result
+    res_diff_kind: CacheResult[str] = cache.check_cache(
+        run_id="run-1", kind_id="my-kind-2", serialized_args=serialized_new
+    )
+    assert not res_diff_kind.found

--- a/tests/workflows/structured/_callcache/test_disk.py
+++ b/tests/workflows/structured/_callcache/test_disk.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Type
+import pytest
+
+from pydantic import BaseModel
+
+from fixpoint.workflows.structured._callcache import CacheResult
+from fixpoint.workflows.structured._callcache._disk import (
+    StepDiskCallCache,
+    TaskDiskCallCache,
+)
+
+from .assertions import assert_cache_works
+
+
+@dataclass
+class RetDataClass:
+    val: int
+
+
+class RetPydantic(BaseModel):
+    val: int
+
+
+class TestDiskCallCache:
+    @pytest.mark.parametrize("cache_cls", [StepDiskCallCache, TaskDiskCallCache])
+    def test_basic(
+        self, cache_cls: Type[StepDiskCallCache | TaskDiskCallCache]
+    ) -> None:
+        cache = cache_cls.from_tmpdir()
+        assert_cache_works(cache)
+
+    @pytest.mark.parametrize("cache_cls", [StepDiskCallCache, TaskDiskCallCache])
+    def test_pydantic(
+        self, cache_cls: Type[StepDiskCallCache | TaskDiskCallCache]
+    ) -> None:
+        cache = cache_cls.from_tmpdir()
+
+        res = RetPydantic(val=0)
+        cache.store_result(run_id="run", kind_id="kind", serialized_args="s0", res=res)
+        cached: CacheResult[RetPydantic] = cache.check_cache(
+            run_id="run", kind_id="kind", serialized_args="s0", type_hint=RetPydantic
+        )
+        assert cached.found
+        assert cached.result == res
+
+    @pytest.mark.parametrize("cache_cls", [StepDiskCallCache, TaskDiskCallCache])
+    def test_dataclass(
+        self, cache_cls: Type[StepDiskCallCache | TaskDiskCallCache]
+    ) -> None:
+        cache = cache_cls.from_tmpdir()
+
+        res = RetDataClass(val=0)
+        cache.store_result(run_id="run", kind_id="kind", serialized_args="s0", res=res)
+        cached: CacheResult[RetDataClass] = cache.check_cache(
+            run_id="run", kind_id="kind", serialized_args="s0", type_hint=RetDataClass
+        )
+        assert cached.found
+        assert cached.result == res

--- a/tests/workflows/structured/_callcache/test_in_mem.py
+++ b/tests/workflows/structured/_callcache/test_in_mem.py
@@ -1,16 +1,12 @@
 from typing import Type
 import pytest
 
-from fixpoint.workflows.structured._callcache import (
-    serialize_args,
-    CacheResult,
-)
 from fixpoint.workflows.structured._callcache._in_mem import (
     StepInMemCallCache,
     TaskInMemCallCache,
 )
 
-from .fixtures import DC, DCInner
+from .assertions import assert_cache_works
 
 
 class TestInMemCallCache:
@@ -19,43 +15,4 @@ class TestInMemCallCache:
         self, cache_cls: Type[StepInMemCallCache | TaskInMemCallCache]
     ) -> None:
         cache = cache_cls()
-        pbm = DC(
-            xyz=DCInner(key200={"x": 99, "a": 50}, key100=100),
-            abc={"x": 2000, "a": 3000},
-            middle=["a", "b", "c"],
-        )
-        serialized = serialize_args(pbm, "something_else", foo="bar")
-
-        res: CacheResult[str] = cache.check_cache(
-            run_id="run-1", kind_id="my-kind", serialized_args=serialized
-        )
-        assert not res.found
-
-        cache.store_result(
-            run_id="run-1", kind_id="my-kind", serialized_args=serialized, res="result0"
-        )
-
-        # recreate the args and see if we get the right result
-        pbm_new = DC(
-            xyz=DCInner(key200={"x": 99, "a": 50}, key100=100),
-            abc={"x": 2000, "a": 3000},
-            middle=["a", "b", "c"],
-        )
-        serialized_new = serialize_args(pbm_new, "something_else", foo="bar")
-        res_new: CacheResult[str] = cache.check_cache(
-            run_id="run-1", kind_id="my-kind", serialized_args=serialized_new
-        )
-        assert res_new.found
-        assert res_new.result == "result0"
-
-        # With a different workflow run, we get a different result
-        res_diff_run: CacheResult[str] = cache.check_cache(
-            run_id="run-2", kind_id="my-kind", serialized_args=serialized_new
-        )
-        assert not res_diff_run.found
-
-        # with a different step/task ID, we get a different result
-        res_diff_kind: CacheResult[str] = cache.check_cache(
-            run_id="run-1", kind_id="my-kind-2", serialized_args=serialized_new
-        )
-        assert not res_diff_kind.found
+        assert_cache_works(cache)


### PR DESCRIPTION
Add a structured workflows call-cache for tasks and steps that caches on-disk.

The on-disk callcache to be able to directly accept cache objects so that we can share the same cache for both tasks and steps.

Hook up the on-disk call-cache in the `RunConfig` settings so we can easily configure on-disk caching for structured workflows.