### PR TITLE
Skeleton code for on-disk memory support

### DIFF
--- a/examples/simple_memory_and_structure.py
+++ b/examples/simple_memory_and_structure.py
@@ -63,7 +63,8 @@ for city in completion.fixp.structured_output.cities:
 
 
 # Look at the agent's memories to see the past chats.
-assert len(agent.fixp.memory.memories()) == 1
+assert len(list(agent.fixp.memory.memories())) == 1
 print("\n")
-print(agent.fixp.memory.memories()[0].messages)
-print(agent.fixp.memory.memories()[0].completion.choices[0].model_dump())
+mems = list(agent.fixp.memory.memories())
+print(mems[0].messages)
+print(mems[0].completion.choices[0].model_dump())

--- a/src/fixpoint/memory/__init__.py
+++ b/src/fixpoint/memory/__init__.py
@@ -1,11 +1,14 @@
 """LLM agent memory"""
 
-from ._memory import Memory, SupportsMemory, MemoryItem
-from ._no_op_memory import NoOpMemory
-
 __all__ = [
     "Memory",
+    "OnDiskMemory",
+    "SupabaseMemory",
     "SupportsMemory",
     "MemoryItem",
     "NoOpMemory",
 ]
+
+from .protocol import SupportsMemory, MemoryItem
+from ._memory import Memory, OnDiskMemory, SupabaseMemory
+from ._no_op_memory import NoOpMemory

--- a/src/fixpoint/memory/_mem_storage.py
+++ b/src/fixpoint/memory/_mem_storage.py
@@ -1,0 +1,95 @@
+"""Memory storage protocol and implementations."""
+
+__all__ = ["MemoryStorage", "OnDiskMemoryStorage"]
+
+from dataclasses import dataclass
+from typing import List, Protocol, Optional
+
+import diskcache
+
+from fixpoint._storage import SupabaseStorage
+from .protocol import MemoryItem
+
+
+@dataclass
+class _ListResponse:
+    """A list memories response"""
+
+    memories: List[MemoryItem]
+    next_cursor: Optional[str] = None
+
+
+class MemoryStorage(Protocol):
+    """Protocol for storing memories"""
+
+    def insert(self, memory: MemoryItem) -> None:
+        """Insert a memory into the storage"""
+
+    def list(self, cursor: Optional[str] = None) -> _ListResponse:
+        """Get the list of memories"""
+
+    def get(self, mem_id: str) -> Optional[MemoryItem]:
+        """Get a memory item by ID"""
+
+
+class OnDiskMemoryStorage(MemoryStorage):
+    """Store memories on disk"""
+
+    _cache: diskcache.Cache
+
+    def __init__(
+        self,
+        cache: diskcache.Cache,
+    ) -> None:
+        self._cache = cache
+
+    def insert(self, memory: MemoryItem) -> None:
+        """Insert a memory into the storage"""
+        raise NotImplementedError()
+
+    def list(self, cursor: Optional[str] = None) -> _ListResponse:
+        """Get the list of memories"""
+        raise NotImplementedError()
+
+    def get(self, mem_id: str) -> Optional[MemoryItem]:
+        """Get a memory item by ID"""
+        raise NotImplementedError()
+
+
+class SupabaseMemoryStorage(MemoryStorage):
+    """Store memories in Supabase"""
+
+    _storage: SupabaseStorage[MemoryItem]
+    _agent_id: str
+
+    def __init__(
+        self,
+        supabase_url: str,
+        supabase_api_key: str,
+    ) -> None:
+        self._storage = SupabaseStorage(
+            url=supabase_url,
+            key=supabase_api_key,
+            table="memory_store",
+            # TODO(dbmikus) what should we do about composite ID columns?
+            # Personally, I think we should not use the generic SupabaseStorage
+            # class for storing agent memories, and instead pass in an interface
+            # that is resource-oriented around these memories
+            order_key="agent_id",
+            id_column="id",
+            value_type=MemoryItem,
+        )
+
+    def insert(self, memory: MemoryItem) -> None:
+        """Insert a memory into the storage"""
+        self._storage.insert(memory)
+
+    def list(self, cursor: Optional[str] = None) -> _ListResponse:
+        """Get the list of memories"""
+        # TODO(dbmikus) support paginating through memories
+        entries = self._storage.fetch_latest()
+        return _ListResponse(memories=entries, next_cursor=None)
+
+    def get(self, mem_id: str) -> Optional[MemoryItem]:
+        """Get a memory item by ID"""
+        return self._storage.fetch(mem_id)

--- a/src/fixpoint/memory/_no_op_memory.py
+++ b/src/fixpoint/memory/_no_op_memory.py
@@ -1,20 +1,20 @@
 """A memory class that stores no memories."""
 
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from pydantic import BaseModel
 
 from fixpoint.completions import ChatCompletionMessageParam, ChatCompletion
 from fixpoint._protocols.workflow_run import WorkflowRunData
-from ._memory import SupportsMemory, MemoryItem
+from .protocol import SupportsMemory, MemoryItem
 
 
 class NoOpMemory(SupportsMemory):
     """A memory class that stores no memories."""
 
-    def memories(self) -> List[MemoryItem]:
+    def memories(self) -> Iterator[MemoryItem]:
         """Get the list of memories"""
-        return []
+        yield from []
 
     def store_memory(
         self,
@@ -24,6 +24,10 @@ class NoOpMemory(SupportsMemory):
         workflow_run: Optional[WorkflowRunData] = None,
     ) -> None:
         """Store the memory"""
+
+    def get(self, mem_id: str) -> Optional[MemoryItem]:
+        """Get a memory item by ID"""
+        return None
 
     def to_str(self) -> str:
         """Return the formatted string of messages. Useful for printing/debugging"""

--- a/src/fixpoint/memory/protocol.py
+++ b/src/fixpoint/memory/protocol.py
@@ -1,0 +1,115 @@
+"""Protocols for memory"""
+
+__all__ = ["MemoryItem", "SupportsMemory"]
+
+
+import json
+from typing import Iterator, List, Protocol, Optional, Any, Callable
+
+from pydantic import BaseModel
+
+from fixpoint._protocols.workflow_run import WorkflowRunData
+from fixpoint._utils.ids import make_resource_uuid
+from fixpoint.completions import ChatCompletionMessageParam, ChatCompletion
+
+
+def new_memory_item_id() -> str:
+    """Generate a new memory item ID"""
+    return make_resource_uuid("amem")
+
+
+class MemoryItem:
+    """A single memory item"""
+
+    # The ID field is useful when identifying this resource in storage, or in a
+    # future HTTP-API
+    id: str
+    agent_id: str
+    messages: List[ChatCompletionMessageParam]
+    completion: ChatCompletion[BaseModel]
+    workflow_id: Optional[str] = None
+    workflow_run_id: Optional[str] = None
+
+    def __init__(
+        self,
+        agent_id: str,
+        messages: List[ChatCompletionMessageParam],
+        completion: ChatCompletion[BaseModel],
+        workflow_run: Optional[WorkflowRunData] = None,
+        workflow_id: Optional[str] = None,
+        workflow_run_id: Optional[str] = None,
+        serialize_fn: Callable[[Any], str] = json.dumps,
+        deserialize_fn: Callable[[str], Any] = json.loads,
+        _id: Optional[str] = None,
+    ) -> None:
+        """
+        In general, you should not pass in an ID, but it exists on the init
+        function for deserializing from storage.
+        """
+        if workflow_run and (workflow_id or workflow_run_id):
+            raise ValueError(
+                'you cannot pass "workflow_run" alongside "workflow_id" or "workflow_run_id"'
+            )
+
+        self.id = _id or new_memory_item_id()
+        self.agent_id = agent_id
+        self.messages = messages
+        self.completion = completion
+
+        if workflow_run:
+            self.workflow_id = workflow_run.workflow_id
+            self.workflow_run_id = workflow_run.id
+        else:
+            self.workflow_id = workflow_id
+            self.workflow_run_id = workflow_run_id
+
+        self._serialize_fn = serialize_fn
+        self._deserialize_fn = deserialize_fn
+
+    def serialize(self) -> dict[str, Any]:
+        """Convert the item to a dictionary"""
+        return {
+            "id": self.id,
+            "agent_id": self.agent_id,
+            "messages": self._serialize_fn(self.messages),
+            "completion": self.completion.serialize_json(),
+            "workflow_id": self.workflow_id,
+            "workflow_run_id": self.workflow_run_id,
+        }
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> "MemoryItem":
+        """Deserialize a dictionary into a TLRUCacheItem"""
+
+        return cls(
+            _id=data.pop("id"),
+            agent_id=data.pop("agent_id"),
+            messages=json.loads(data.pop("messages")),
+            completion=ChatCompletion[BaseModel].deserialize_json(
+                data.pop("completion")
+            ),
+            workflow_id=data.pop("workflow_id"),
+            workflow_run_id=data.pop("workflow_run_id"),
+        )
+
+
+class SupportsMemory(Protocol):
+    """A protocol for adding memory to an agent"""
+
+    def memories(self) -> Iterator[MemoryItem]:
+        """Get the list of memories"""
+
+    def store_memory(
+        self,
+        agent_id: str,
+        messages: List[ChatCompletionMessageParam],
+        completion: ChatCompletion[BaseModel],
+        workflow_run: Optional[WorkflowRunData] = None,
+    ) -> None:
+        """Store the memory"""
+
+    def get(self, mem_id: str) -> Optional[MemoryItem]:
+        """Get a memory item by ID"""
+
+    def to_str(self) -> str:
+        """Return the formatted string of messages. Useful for printing/debugging"""

--- a/src/fixpoint/workflows/imperative/config.py
+++ b/src/fixpoint/workflows/imperative/config.py
@@ -53,12 +53,12 @@ class StorageConfig:
             ),
         )
 
+        # pylint: disable=unused-argument
         def memory_factory(agent_id: str) -> memory.SupportsMemory:
             """create memory collections per agent"""
-            return memory.Memory(
-                storage=create_memory_supabase_storage(
-                    supabase_url, supabase_api_key, agent_id
-                ),
+            return memory.SupabaseMemory(
+                supabase_url=supabase_url,
+                supabase_api_key=supabase_api_key,
             )
 
         return cls(
@@ -174,7 +174,7 @@ def create_str_cache_supabase_storage(
     )
 
 
-def create_memory_supabase_storage(
+def _create_memory_supabase_storage(
     supabase_url: str,
     supabase_api_key: str,
     agent_id: str,  # pylint: disable=unused-argument

--- a/tests/agents/mock_test.py
+++ b/tests/agents/mock_test.py
@@ -19,7 +19,7 @@ class TestMockAgent:
             completion_fn=MockCompletionGenerator().new_mock_completion, memory=mem
         )
 
-        assert mem.memories() == []
+        assert list(mem.memories()) == []
         cmpl = agent.create_completion(
             messages=[
                 messages.smsg("I am a system"),
@@ -27,7 +27,7 @@ class TestMockAgent:
             ]
         )
         assert cmpl.choices[0].message.content == "test 0"
-        mems = mem.memories()
+        mems = list(mem.memories())
         assert len(mems) == 1
         assert mems[0].messages == [
             messages.smsg("I am a system"),

--- a/tests/experimental/agents/test_memgpt.py
+++ b/tests/experimental/agents/test_memgpt.py
@@ -30,10 +30,10 @@ class TestMemGPTSummaryAgent:
         )
 
         # We are under the token limit, so we don't summarize.
-        assert len(mem.memories()) == 1
+        assert len(list(mem.memories())) == 1
         # We are under the token limit, so we did not summarize and product any
         # extra messages.
-        assert len(mem.memories()[0].messages) == 2
+        assert len(list(mem.memories())[0].messages) == 2
 
 
 def test_context_length_check() -> None:


### PR DESCRIPTION
Prepare the code for on-disk memory storage. We made it so we have a `_mem_storage` module with a `MemoryStorage` protocol instead of using the generic `SupportsStorage` protocol.

We migrated Supabase storage over to use `MemoryStorage`, and have unimplemented stubs for on-disk memory storage.