### PR TITLE
Add protocol for doc and form storage in workflows

### DIFF
--- a/src/fixpoint/workflows/imperative/_doc_storage.py
+++ b/src/fixpoint/workflows/imperative/_doc_storage.py
@@ -1,0 +1,57 @@
+"""Document storage for workflows"""
+
+__all__ = ["DocStorage", "SupabaseDocStorage"]
+
+from typing import List, Optional, Protocol
+
+from fixpoint._storage import SupportsStorage
+from .document import Document
+
+
+class DocStorage(Protocol):
+    """Document storage for workflows"""
+
+    # pylint: disable=redefined-builtin
+    def get(self, id: str) -> Optional[Document]:
+        """Get the given document"""
+
+    def create(self, document: Document) -> None:
+        """Create a new document"""
+
+    def update(self, document: Document) -> None:
+        """Update an existing document"""
+
+    def list(
+        self, path: Optional[str] = None, workflow_run_id: Optional[str] = None
+    ) -> List[Document]:
+        """List all documents
+
+        If path is provided, list documents in the given path.
+        """
+
+
+class SupabaseDocStorage(DocStorage):
+    """Supabase document storage for workflows"""
+
+    _storage: SupportsStorage[Document]
+
+    def __init__(self, storage: SupportsStorage[Document]):
+        self._storage = storage
+
+    # pylint: disable=redefined-builtin
+    def get(self, id: str) -> Optional[Document]:
+        return self._storage.fetch(id)
+
+    def create(self, document: Document) -> None:
+        self._storage.insert(document)
+
+    def update(self, document: Document) -> None:
+        self._storage.update(document)
+
+    def list(
+        self, path: Optional[str] = None, workflow_run_id: Optional[str] = None
+    ) -> List[Document]:
+        conditions = {"workflow_run_id": workflow_run_id}
+        if path:
+            conditions["path"] = path
+        return self._storage.fetch_with_conditions(conditions)

--- a/src/fixpoint/workflows/imperative/_form_storage.py
+++ b/src/fixpoint/workflows/imperative/_form_storage.py
@@ -1,0 +1,59 @@
+"""Form storage for workflows"""
+
+__all__ = ["FormStorage", "SupabaseFormStorage"]
+
+from typing import List, Optional, Protocol
+
+from pydantic import BaseModel
+
+from fixpoint._storage import SupportsStorage
+from .form import Form
+
+
+class FormStorage(Protocol):
+    """Form storage for workflows"""
+
+    # pylint: disable=redefined-builtin
+    def get(self, id: str) -> Optional[Form[BaseModel]]:
+        """Get the given Form"""
+
+    def create(self, form: Form[BaseModel]) -> None:
+        """Create a new Form"""
+
+    def update(self, form: Form[BaseModel]) -> None:
+        """Update an existing Form"""
+
+    def list(
+        self, path: Optional[str] = None, workflow_run_id: Optional[str] = None
+    ) -> List[Form[BaseModel]]:
+        """List all Forms
+
+        If path is provided, list Forms in the given path.
+        """
+
+
+class SupabaseFormStorage(FormStorage):
+    """Supabase form storage for workflows"""
+
+    _storage: SupportsStorage[Form[BaseModel]]
+
+    def __init__(self, storage: SupportsStorage[Form[BaseModel]]):
+        self._storage = storage
+
+    # pylint: disable=redefined-builtin
+    def get(self, id: str) -> Optional[Form[BaseModel]]:
+        return self._storage.fetch(id)
+
+    def create(self, form: Form[BaseModel]) -> None:
+        self._storage.insert(form)
+
+    def update(self, form: Form[BaseModel]) -> None:
+        self._storage.update(form)
+
+    def list(
+        self, path: Optional[str] = None, workflow_run_id: Optional[str] = None
+    ) -> List[Form[BaseModel]]:
+        conditions = {"workflow_run_id": workflow_run_id}
+        if path:
+            conditions["path"] = path
+        return self._storage.fetch_with_conditions(conditions)

--- a/src/fixpoint/workflows/imperative/workflow.py
+++ b/src/fixpoint/workflows/imperative/workflow.py
@@ -17,8 +17,8 @@ from fixpoint.workflows.node_state import NodeState, CallHandle, SpawnGroup, Nod
 from .document import Document
 from .form import Form
 from .config import StorageConfig, get_default_storage_config
-from ._doc_storage import DocStorage, SupabaseDocStorage
-from ._form_storage import FormStorage, SupabaseFormStorage
+from ._doc_storage import DocStorage
+from ._form_storage import FormStorage
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -94,11 +94,10 @@ class WorkflowRun(BaseModel):
         docs_storage: Optional[DocStorage] = None
         forms_storage: Optional[FormStorage] = None
         if self.storage_config:
-            # TODO(dbmikus) support SQLite storage
             if self.storage_config.docs_storage:
-                docs_storage = SupabaseDocStorage(self.storage_config.docs_storage)
+                docs_storage = self.storage_config.docs_storage
             if self.storage_config.forms_storage:
-                forms_storage = SupabaseFormStorage(self.storage_config.forms_storage)
+                forms_storage = self.storage_config.forms_storage
         self._documents = _Documents(workflow_run=self, storage=docs_storage)
         self._forms = _Forms(workflow_run=self, storage=forms_storage)
 

--- a/src/fixpoint/workflows/imperative/workflow.py
+++ b/src/fixpoint/workflows/imperative/workflow.py
@@ -11,13 +11,14 @@ from pydantic import (
     SkipValidation,
 )
 
-from fixpoint._storage.protocol import SupportsStorage
 from fixpoint._utils.ids import make_resource_uuid
 from fixpoint.workflows.node_state import NodeState, CallHandle, SpawnGroup, NodeInfo
 
 from .document import Document
 from .form import Form
 from .config import StorageConfig, get_default_storage_config
+from ._doc_storage import DocStorage, SupabaseDocStorage
+from ._form_storage import FormStorage, SupabaseFormStorage
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -90,11 +91,14 @@ class WorkflowRun(BaseModel):
         return self._id
 
     def model_post_init(self, _context: Any) -> None:
-        docs_storage = None
-        forms_storage = None
+        docs_storage: Optional[DocStorage] = None
+        forms_storage: Optional[FormStorage] = None
         if self.storage_config:
-            docs_storage = self.storage_config.docs_storage
-            forms_storage = self.storage_config.forms_storage
+            # TODO(dbmikus) support SQLite storage
+            if self.storage_config.docs_storage:
+                docs_storage = SupabaseDocStorage(self.storage_config.docs_storage)
+            if self.storage_config.forms_storage:
+                forms_storage = SupabaseFormStorage(self.storage_config.forms_storage)
         self._documents = _Documents(workflow_run=self, storage=docs_storage)
         self._forms = _Forms(workflow_run=self, storage=forms_storage)
 
@@ -176,13 +180,13 @@ class WorkflowRun(BaseModel):
 
 class _Documents:
     workflow_run: WorkflowRun
-    _storage: Optional[SupportsStorage[Document]]
+    _storage: Optional[DocStorage]
     _memory: Dict[str, Document]
 
     def __init__(
         self,
         workflow_run: WorkflowRun,
-        storage: Optional[SupportsStorage[Document]] = None,
+        storage: Optional[DocStorage] = None,
     ) -> None:
         self.workflow_run = workflow_run
         self._storage = storage
@@ -198,7 +202,7 @@ class _Documents:
         """
         document = None
         if self._storage:
-            document = self._storage.fetch(resource_id=document_id)
+            document = self._storage.get(document_id)
         else:
             document = self._memory.get(document_id, None)
         return document
@@ -232,7 +236,7 @@ class _Documents:
             workflow_run_id=self.workflow_run.id,
         )
         if self._storage:
-            self._storage.insert(document)
+            self._storage.create(document)
         else:
             self._memory[id] = document
         return document
@@ -274,13 +278,15 @@ class _Documents:
         we list all documents at the root of the workflow, outside of all tasks and
         steps.
         """
-        conditions = {"workflow_run_id": self.workflow_run.id}
-        if path:
-            conditions["path"] = path
 
         if self._storage:
-            documents = self._storage.fetch_with_conditions(conditions=conditions)
+            documents = self._storage.list(
+                path=path, workflow_run_id=self.workflow_run.id
+            )
         else:
+            conditions = {"workflow_run_id": self.workflow_run.id}
+            if path:
+                conditions["path"] = path
             documents = [
                 doc
                 for doc in self._memory.values()
@@ -294,13 +300,13 @@ class _Documents:
 
 class _Forms:
     workflow_run: WorkflowRun
-    _storage: Optional[SupportsStorage[Form[BaseModel]]]
+    _storage: Optional[FormStorage]
     _memory: Dict[str, Form[BaseModel]]
 
     def __init__(
         self,
         workflow_run: WorkflowRun,
-        storage: Optional[SupportsStorage[Form[BaseModel]]] = None,
+        storage: Optional[FormStorage] = None,
     ) -> None:
         self.workflow_run = workflow_run
         self._storage = storage
@@ -314,7 +320,7 @@ class _Forms:
         form = None
         if self._storage:
             # Form id is the primary identifier for a form, so specifying more fields is unecessary
-            form = self._storage.fetch(resource_id=form_id)
+            form = self._storage.get(form_id)
         else:
             # If we are not using a storage backend, we assume that the form is in memory
             form = self._memory.get(form_id, None)
@@ -351,7 +357,7 @@ class _Forms:
         )
         if self._storage:
             # Storage layer only expects "BaseModel"
-            self._storage.insert(cast(Form[BaseModel], form))
+            self._storage.create(cast(Form[BaseModel], form))
         else:
             self._memory[form_id] = cast(Form[BaseModel], form)
 
@@ -402,16 +408,18 @@ class _Forms:
         """
         forms_with_meta: List[Form[BaseModel]] = []
         forms: List[Form[BaseModel]] = []
-        conditions = {"workflow_run_id": self.workflow_run.id}
-        if path:
-            conditions["path"] = path
         if self._storage:
-            forms_with_meta = self._storage.fetch_with_conditions(conditions=conditions)
+            forms_with_meta = self._storage.list(
+                path=path, workflow_run_id=self.workflow_run.id
+            )
             forms = [
                 Form(**form_with_meta.model_dump())
                 for form_with_meta in forms_with_meta
             ]
         else:
+            conditions = {"workflow_run_id": self.workflow_run.id}
+            if path:
+                conditions["path"] = path
             # Filter forms in memory based on conditions
             forms = [
                 Form(**form_with_meta.model_dump())


### PR DESCRIPTION
Add a protocol for doc and form storage in workflows. We used to just use the generic `SupportsStorage` protocol for `Document` and `Form` classes, but that started to become complicated when I was trying to write the SQLite on-disk implementations.

So we go to a resource-based approach, where we have a protocol specified for how to interact specifically with forms and docs.

I added a Supabase compatible implementation of this protocol, which mostly just pipes things through to the old `SupabaseStorage` class.