### PR TITLE
[structured] Fix WorkflowContext clone

### DIFF
--- a/src/fixpoint/workflows/imperative/_wrapped_workflow_agents.py
+++ b/src/fixpoint/workflows/imperative/_wrapped_workflow_agents.py
@@ -1,0 +1,101 @@
+"""Wrapped agents scoped to a workflow run"""
+
+__all__ = ["WrappedWorkflowAgents"]
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from fixpoint.agents import BaseAgent
+from fixpoint.memory import NoOpMemory, Memory
+from .workflow import WorkflowRun
+from ._workflow_agent import WorkflowAgent
+
+
+class WrappedWorkflowAgents:
+    """Wrapped agents scoped to a workflow run"""
+
+    _agents: Dict[str, WorkflowAgent]
+    _workflow_run: WorkflowRun
+
+    def __init__(
+        self,
+        agents: List[BaseAgent],
+        workflow_run: WorkflowRun,
+        *,
+        _workflow_agents_override_: Optional[Dict[str, WorkflowAgent]] = None,
+    ) -> None:
+        self._workflow_run = workflow_run
+
+        if _workflow_agents_override_ is None:
+            agents_dict = {agent.id: agent for agent in agents}
+            if len(agents_dict) != len(agents):
+                raise ValueError("Duplicate agent ids are not allowed")
+            self._agents = self._prepare_agents(workflow_run, agents_dict)
+        else:
+            if len(_workflow_agents_override_) != len(
+                {agent.id: agent for agent in _workflow_agents_override_.values()}
+            ):
+                raise ValueError("Duplicate agent ids are not allowed")
+            self._agents = _workflow_agents_override_
+
+    def __getitem__(self, key: str) -> BaseAgent:
+        return self._agents[key]
+
+    def __setitem__(self, key: str, agent: BaseAgent) -> None:
+        self._agents[key] = self._wrap_agent(self._workflow_run, agent)
+
+    def keys(self) -> Iterable[str]:
+        """Returns the agent ids in the workflow"""
+        return self._agents.keys()
+
+    def values(self) -> Iterable[BaseAgent]:
+        """Returns the agents in the workflow"""
+        return self._agents.values()
+
+    def items(self) -> Iterable[Tuple[str, BaseAgent]]:
+        """Returns the (agent ids, agents) in the workflow"""
+        return self._agents.items()
+
+    def _prepare_agents(
+        self, workflow_run: WorkflowRun, agents: Dict[str, BaseAgent]
+    ) -> Dict[str, WorkflowAgent]:
+        new_agents: Dict[str, WorkflowAgent] = {}
+        for name, agent in agents.items():
+            new_agents[name] = self._wrap_agent(workflow_run, agent)
+        return new_agents
+
+    def _update_agents(self, workflow_run: WorkflowRun) -> None:
+        for agent in self._agents.values():
+            # pylint: disable=protected-access
+            agent._workflow_run = workflow_run
+
+    def _wrap_agent(self, workflow_run: WorkflowRun, agent: BaseAgent) -> WorkflowAgent:
+        # We require agents in a workflow to have working memory
+        if isinstance(agent.memory, NoOpMemory):
+            if workflow_run.storage_config:
+                agent.memory = workflow_run.storage_config.memory_factory(agent.id)
+            else:
+                agent.memory = Memory()
+        return WorkflowAgent(agent, workflow_run)
+
+    def clone(
+        self, new_workflow_run: Optional[WorkflowRun] = None
+    ) -> "WrappedWorkflowAgents":
+        """Clones the workflow context"""
+        workflow_run = self._workflow_run
+        if new_workflow_run:
+            workflow_run = new_workflow_run
+        new_agents = {
+            # pylint: disable=protected-access
+            k: WorkflowAgent(v._inner_agent, workflow_run)
+            for k, v in self._agents.items()
+        }
+
+        new_self = self.__class__(
+            agents=[],
+            workflow_run=workflow_run,
+            _workflow_agents_override_=new_agents,
+        )
+        if new_workflow_run:
+            # pylint: disable=protected-access
+            new_self._update_agents(workflow_run)
+        return new_self

--- a/src/fixpoint/workflows/imperative/workflow_context.py
+++ b/src/fixpoint/workflows/imperative/workflow_context.py
@@ -1,102 +1,12 @@
 """The context for a workflow"""
 
 import logging
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import List, Optional
 
 from fixpoint.agents import BaseAgent
 from fixpoint.cache import SupportsChatCompletionCache
-from fixpoint.memory import NoOpMemory, Memory
 from .workflow import WorkflowRun
-from ._workflow_agent import WorkflowAgent
-
-
-class _WrappedWorkflowAgents:
-    _agents: Dict[str, WorkflowAgent]
-    _workflow_run: WorkflowRun
-
-    def __init__(
-        self,
-        agents: List[BaseAgent],
-        workflow_run: WorkflowRun,
-        *,
-        _workflow_agents_override_: Optional[Dict[str, WorkflowAgent]] = None,
-    ) -> None:
-        self._workflow_run = workflow_run
-
-        if _workflow_agents_override_ is None:
-            agents_dict = {agent.id: agent for agent in agents}
-            if len(agents_dict) != len(agents):
-                raise ValueError("Duplicate agent ids are not allowed")
-            self._agents = self._prepare_agents(workflow_run, agents_dict)
-        else:
-            if len(_workflow_agents_override_) != len(
-                {agent.id: agent for agent in _workflow_agents_override_.values()}
-            ):
-                raise ValueError("Duplicate agent ids are not allowed")
-            self._agents = _workflow_agents_override_
-
-    def __getitem__(self, key: str) -> BaseAgent:
-        return self._agents[key]
-
-    def __setitem__(self, key: str, agent: BaseAgent) -> None:
-        self._agents[key] = self._wrap_agent(self._workflow_run, agent)
-
-    def keys(self) -> Iterable[str]:
-        """Returns the agent ids in the workflow"""
-        return self._agents.keys()
-
-    def values(self) -> Iterable[BaseAgent]:
-        """Returns the agents in the workflow"""
-        return self._agents.values()
-
-    def items(self) -> Iterable[Tuple[str, BaseAgent]]:
-        """Returns the (agent ids, agents) in the workflow"""
-        return self._agents.items()
-
-    def _prepare_agents(
-        self, workflow_run: WorkflowRun, agents: Dict[str, BaseAgent]
-    ) -> Dict[str, WorkflowAgent]:
-        new_agents: Dict[str, WorkflowAgent] = {}
-        for name, agent in agents.items():
-            new_agents[name] = self._wrap_agent(workflow_run, agent)
-        return new_agents
-
-    def _update_agents(self, workflow_run: WorkflowRun) -> None:
-        for agent in self._agents.values():
-            # pylint: disable=protected-access
-            agent._workflow_run = workflow_run
-
-    def _wrap_agent(self, workflow_run: WorkflowRun, agent: BaseAgent) -> WorkflowAgent:
-        # We require agents in a workflow to have working memory
-        if isinstance(agent.memory, NoOpMemory):
-            if workflow_run.storage_config:
-                agent.memory = workflow_run.storage_config.memory_factory(agent.id)
-            else:
-                agent.memory = Memory()
-        return WorkflowAgent(agent, workflow_run)
-
-    def clone(
-        self, new_workflow_run: Optional[WorkflowRun] = None
-    ) -> "_WrappedWorkflowAgents":
-        """Clones the workflow context"""
-        workflow_run = self._workflow_run
-        if new_workflow_run:
-            workflow_run = new_workflow_run
-        new_agents = {
-            # pylint: disable=protected-access
-            k: WorkflowAgent(v._inner_agent, workflow_run)
-            for k, v in self._agents.items()
-        }
-
-        new_self = self.__class__(
-            agents=[],
-            workflow_run=workflow_run,
-            _workflow_agents_override_=new_agents,
-        )
-        if new_workflow_run:
-            # pylint: disable=protected-access
-            new_self._update_agents(workflow_run)
-        return new_self
+from ._wrapped_workflow_agents import WrappedWorkflowAgents
 
 
 class WorkflowContext:
@@ -106,7 +16,7 @@ class WorkflowContext:
     function of your workflow.
     """
 
-    agents: _WrappedWorkflowAgents
+    agents: WrappedWorkflowAgents
     workflow_run: WorkflowRun
     cache: Optional[SupportsChatCompletionCache]
     logger: logging.Logger
@@ -118,10 +28,10 @@ class WorkflowContext:
         cache: Optional[SupportsChatCompletionCache] = None,
         logger: Optional[logging.Logger] = None,
         *,
-        _workflow_agents_override_: Optional[_WrappedWorkflowAgents] = None,
+        _workflow_agents_override_: Optional[WrappedWorkflowAgents] = None,
     ) -> None:
         if _workflow_agents_override_ is None:
-            self.agents = _WrappedWorkflowAgents(agents, workflow_run)
+            self.agents = WrappedWorkflowAgents(agents, workflow_run)
         else:
             self.agents = _workflow_agents_override_
         self.workflow_run = workflow_run

--- a/src/fixpoint/workflows/structured/_context.py
+++ b/src/fixpoint/workflows/structured/_context.py
@@ -42,5 +42,31 @@ class WorkflowContext(ImperativeWorkflowContext):
         *,
         _workflow_agents_override_: Optional[WrappedWorkflowAgents] = None,
     ) -> None:
-        super().__init__(workflow_run, agents, cache, logger)
+        super().__init__(
+            workflow_run,
+            agents,
+            cache,
+            logger,
+            _workflow_agents_override_=_workflow_agents_override_,
+        )
         self.run_config = run_config
+
+    def clone(self) -> "WorkflowContext":
+        """Clones the workflow context"""
+
+        # We need to override this metod from the child class because we have
+        # different init parameters.
+
+        # clone the workflow run
+        new_workflow_run = self.workflow_run.clone()
+        # clone the agents
+        new_agents = self.agents.clone(new_workflow_run)
+
+        return self.__class__(
+            agents=[],
+            workflow_run=new_workflow_run,
+            cache=self.cache,
+            logger=self.logger,
+            run_config=self.run_config,
+            _workflow_agents_override_=new_agents,
+        )

--- a/src/fixpoint/workflows/structured/_context.py
+++ b/src/fixpoint/workflows/structured/_context.py
@@ -7,6 +7,7 @@ from fixpoint.agents import BaseAgent
 from fixpoint.cache import SupportsChatCompletionCache
 
 from ..imperative import WorkflowContext as ImperativeWorkflowContext, WorkflowRun
+from ..imperative._wrapped_workflow_agents import WrappedWorkflowAgents
 from ._run_config import RunConfig
 
 
@@ -38,6 +39,8 @@ class WorkflowContext(ImperativeWorkflowContext):
         agents: List[BaseAgent],
         cache: Optional[SupportsChatCompletionCache] = None,
         logger: Optional[logging.Logger] = None,
+        *,
+        _workflow_agents_override_: Optional[WrappedWorkflowAgents] = None,
     ) -> None:
         super().__init__(workflow_run, agents, cache, logger)
         self.run_config = run_config

--- a/tests/workflows/imperative/test_workflow_context.py
+++ b/tests/workflows/imperative/test_workflow_context.py
@@ -4,10 +4,8 @@ from fixpoint.cache import ChatCompletionTLRUCache
 from fixpoint.agents import BaseAgent
 from fixpoint.agents.mock import MockAgent, new_mock_completion
 from fixpoint.workflows import imperative
-from fixpoint.workflows.imperative.workflow_context import (
-    _WrappedWorkflowAgents,
-    WorkflowContext,
-)
+from fixpoint.workflows.imperative._wrapped_workflow_agents import WrappedWorkflowAgents
+from fixpoint.workflows.imperative.workflow_context import WorkflowContext
 from fixpoint.workflows.imperative._workflow_agent import WorkflowAgent
 
 
@@ -20,9 +18,7 @@ class TestWrappedWorkflowAgents:
         workflow_run = workflow.run()
         agents: List[BaseAgent] = [agent1, agent2]
 
-        wrapped_agents = _WrappedWorkflowAgents(
-            agents=agents, workflow_run=workflow_run
-        )
+        wrapped_agents = WrappedWorkflowAgents(agents=agents, workflow_run=workflow_run)
         pre_cloned_agents = wrapped_agents._agents
         pre_cloned_workflow_run = wrapped_agents._workflow_run
         assert wrapped_agents._workflow_run == workflow_run


### PR DESCRIPTION
Fix the structured `WorkflowContext.clone` method by overriding the child class's `clone` method. If we didn't override, there are problems because structured and imperative `WorkflowContext.__init__` methods have different parameters.