### PR TITLE
[structured] Calling tasks and steps updates context

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -440,7 +440,8 @@ disable=raw-checker-failed,
         consider-iterating-dictionary,
         no-else-raise,
         no-member, # disabled because pylint gets this wrong on Pydantic and mypy covers it
-        not-callable # disabled because pylint gets this wrong sometimes and mypy covers it
+        not-callable, # disabled because pylint gets this wrong sometimes and mypy covers it
+        unsupported-binary-operation
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/examples/fastapi_chat_workflows/server.py
+++ b/examples/fastapi_chat_workflows/server.py
@@ -65,7 +65,7 @@ def create_workflow_run() -> WorkflowRun:
 def create_chat(workflow_run_id: str, user_message: str) -> str:
     """Create a chat for a workflow run."""
     wfctx = get_workflow_context(workflow_run_id)
-    task = wfctx.workflow_run.current_node_info.task
+    task = wfctx.workflow_run.node_info.task
     if task == "__main__":
         return classify_task(wfctx, user_message)
     elif task == FormType.INVOICE.value:

--- a/src/fixpoint/workflows/__init__.py
+++ b/src/fixpoint/workflows/__init__.py
@@ -4,6 +4,8 @@ A "workflow" is a series of steps that one or more agents takes to accomplish
 some goal.
 """
 
-__all__ = ["Workflow", "WorkflowRun"]
+__all__ = ["Workflow", "WorkflowRun", "WorkflowStatus", "TASK_MAIN_ID", "STEP_MAIN_ID"]
 
+from .constants import TASK_MAIN_ID, STEP_MAIN_ID
 from ._workflow import Workflow, WorkflowRun
+from .node_state import WorkflowStatus

--- a/src/fixpoint/workflows/constants.py
+++ b/src/fixpoint/workflows/constants.py
@@ -1,0 +1,6 @@
+"""Constants for workflows"""
+
+__all__ = ["TASK_MAIN_ID", "STEP_MAIN_ID"]
+
+TASK_MAIN_ID = "__main__"
+STEP_MAIN_ID = "__main__"

--- a/src/fixpoint/workflows/imperative/shared.py
+++ b/src/fixpoint/workflows/imperative/shared.py
@@ -1,4 +1,0 @@
-"""Shared code for imperative workflows"""
-
-TASK_MAIN_ID = "__main__"
-STEP_MAIN_ID = "__main__"

--- a/src/fixpoint/workflows/imperative/workflow.py
+++ b/src/fixpoint/workflows/imperative/workflow.py
@@ -170,13 +170,20 @@ class WorkflowRun(BaseModel):
         """Handle for spawning a group of tasks"""
         return SpawnGroup(node_state=self._node_state)
 
-    def clone(self) -> "WorkflowRun":
+    def clone(
+        self, new_task: str | None = None, new_step: str | None = None
+    ) -> "WorkflowRun":
         """Clones the workflow run"""
         # we cannot deep copy because some of the fields cannot be pickled,
         # which is what the pydantic copy method uses
         new_self = self.model_copy(deep=False)
         # pylint: disable=protected-access
         new_self._node_state = self._node_state.model_copy(deep=False)
+        new_self._node_state.info = self._node_state.info.model_copy(deep=True)
+        if new_task:
+            new_self._node_state.info.task = new_task
+        if new_step:
+            new_self._node_state.info.step = new_step
         return new_self
 
 

--- a/src/fixpoint/workflows/imperative/workflow.py
+++ b/src/fixpoint/workflows/imperative/workflow.py
@@ -117,8 +117,11 @@ class WorkflowRun(BaseModel):
         return self._forms
 
     @property
-    def current_node_info(self) -> NodeInfo:
-        """The current task"""
+    def node_info(self) -> NodeInfo:
+        """The info about the current execution node
+
+        What task or step are we in, and what is it's status?
+        """
         return self._node_state.info
 
     # pylint: disable=unused-argument
@@ -226,7 +229,7 @@ class _Documents:
         steps. By default, we store the document at the current task and step.
         """
         if path is None:
-            path = self.workflow_run.current_node_info.id
+            path = self.workflow_run.node_info.id
         document = Document(
             id=id,
             workflow_id=self.workflow_run.workflow_id,
@@ -348,7 +351,7 @@ class _Forms:
         """
         # TODO(jakub): Pass in contents as well
         if path is None:
-            path = self.workflow_run.current_node_info.id
+            path = self.workflow_run.node_info.id
         form = Form[T](
             form_schema=schema,
             id=form_id,

--- a/src/fixpoint/workflows/imperative/workflow_context.py
+++ b/src/fixpoint/workflows/imperative/workflow_context.py
@@ -52,10 +52,12 @@ class WorkflowContext:
         # pylint: disable=protected-access
         self.agents._update_agents(workflow_run)
 
-    def clone(self) -> "WorkflowContext":
+    def clone(
+        self, new_task: str | None = None, new_step: str | None = None
+    ) -> "WorkflowContext":
         """Clones the workflow context"""
         # clone the workflow run
-        new_workflow_run = self.workflow_run.clone()
+        new_workflow_run = self.workflow_run.clone(new_task=new_task, new_step=new_step)
         # clone the agents
         new_agents = self.agents.clone(new_workflow_run)
 

--- a/src/fixpoint/workflows/node_state.py
+++ b/src/fixpoint/workflows/node_state.py
@@ -2,14 +2,15 @@
 Node state management for workflows.
 """
 
+__all__ = ["WorkflowStatus", "NodeInfo", "CallHandle", "NodeState", "SpawnGroup"]
+
 import threading
 from enum import Enum
 from types import TracebackType
 from typing import List, Optional, Callable, Union
 from pydantic import BaseModel, Field, computed_field, PrivateAttr
 
-# TODO(jakub): Move shared contents to fixpoint.workflows
-from fixpoint.workflows.imperative.shared import TASK_MAIN_ID, STEP_MAIN_ID
+from fixpoint.workflows.constants import TASK_MAIN_ID, STEP_MAIN_ID
 
 
 class WorkflowStatus(Enum):

--- a/src/fixpoint/workflows/structured/_context.py
+++ b/src/fixpoint/workflows/structured/_context.py
@@ -51,14 +51,16 @@ class WorkflowContext(ImperativeWorkflowContext):
         )
         self.run_config = run_config
 
-    def clone(self) -> "WorkflowContext":
+    def clone(
+        self, new_task: str | None = None, new_step: str | None = None
+    ) -> "WorkflowContext":
         """Clones the workflow context"""
 
         # We need to override this metod from the child class because we have
         # different init parameters.
 
         # clone the workflow run
-        new_workflow_run = self.workflow_run.clone()
+        new_workflow_run = self.workflow_run.clone(new_task=new_task, new_step=new_step)
         # clone the agents
         new_agents = self.agents.clone(new_workflow_run)
 

--- a/src/fixpoint/workflows/structured/_step.py
+++ b/src/fixpoint/workflows/structured/_step.py
@@ -80,9 +80,9 @@ def get_step_fixp(fn: Callable[..., Any]) -> Optional[StepFixp]:
     return None
 
 
-def call_step(
+async def call_step(
     ctx: WorkflowContext,
-    fn: Callable[Params, Ret],
+    fn: AsyncFunc[Params, Ret],
     args: Optional[List[Any]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> Ret:
@@ -118,5 +118,5 @@ def call_step(
     if not step_fixp:
         raise DefinitionException(f"Step {fn.__name__} is not a valid step definition")
 
-    ret = fn(ctx, *args, **kwargs)  # type: ignore[arg-type]
+    ret = await fn(ctx, *args, **kwargs)  # type: ignore[arg-type]
     return ret

--- a/src/fixpoint/workflows/structured/_task.py
+++ b/src/fixpoint/workflows/structured/_task.py
@@ -239,9 +239,9 @@ def get_task_entrypoint_fixp_from_fn(fn: Callable[..., Any]) -> Optional[TaskEnt
     return None
 
 
-def call_task(
+async def call_task(
     ctx: WorkflowContext,
-    task_entry: Callable[Params, Ret],
+    task_entry: AsyncFunc[Params, Ret],
     args: Optional[List[Any]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
 ) -> Ret:
@@ -297,5 +297,5 @@ def call_task(
     kwargs = kwargs or {}
     # The Params type gets confused because we are injecting an additional
     # WorkflowContext. Ignore that error.
-    res = task_entry(task_instance, ctx, *args, **kwargs)  # type: ignore[arg-type]
+    res = await task_entry(task_instance, ctx, *args, **kwargs)  # type: ignore[arg-type]
     return res

--- a/tests/workflows/imperative/test_workflow.py
+++ b/tests/workflows/imperative/test_workflow.py
@@ -33,7 +33,7 @@ class TestWorkflowRun:
         # references are different...
         assert new_run._node_state is not run._node_state
         # but content is the same
-        assert new_run.current_node_info.id == run.current_node_info.id
+        assert new_run.node_info.id == run.node_info.id
 
         # It's fine that workflow is the same, because we do not expect to
         # mutate it.

--- a/tests/workflows/structured/test_task.py
+++ b/tests/workflows/structured/test_task.py
@@ -1,7 +1,9 @@
+from typing import Any, Coroutine
 import pytest
-from fixpoint.workflows import imperative
-from fixpoint.workflows import structured
+from fixpoint.workflows import imperative, structured, TASK_MAIN_ID, STEP_MAIN_ID
 from fixpoint.workflows.structured._run_config import RunConfig
+
+NoneCoro = Coroutine[Any, Any, None]
 
 
 def test_task_declaration() -> None:
@@ -99,3 +101,60 @@ async def test_task_cahce() -> None:
     res = await structured.call_task(ctx, MyTask.run, args=["Jakub"])
     assert res == "Hello, Jakub"
     assert values["counter"] == 2
+
+
+@pytest.mark.asyncio
+async def test_task_context() -> None:
+
+    def assert_ctx_task_step(
+        ctx: structured.WorkflowContext, task: str, step: str
+    ) -> None:
+        assert ctx.workflow_run.node_info.task == task
+        assert ctx.workflow_run.node_info.step == step
+
+    @structured.task("task1")
+    class Task1:
+        @structured.task_entrypoint()
+        async def run(self, ctx: structured.WorkflowContext) -> None:
+            assert_ctx_task_step(ctx, "task1", STEP_MAIN_ID)
+            step1_future: NoneCoro = structured.call_step(ctx, step1, args=["task1"])
+            step2_future: NoneCoro = structured.call_step(ctx, step2, args=["task1"])
+            assert_ctx_task_step(ctx, "task1", STEP_MAIN_ID)
+            await step1_future
+            assert_ctx_task_step(ctx, "task1", STEP_MAIN_ID)
+            await step2_future
+            assert_ctx_task_step(ctx, "task1", STEP_MAIN_ID)
+
+    @structured.task("task2")
+    class Task2:
+        @structured.task_entrypoint()
+        async def run(self, ctx: structured.WorkflowContext) -> None:
+            assert_ctx_task_step(ctx, "task2", STEP_MAIN_ID)
+            step1_future: NoneCoro = structured.call_step(ctx, step1, args=["task2"])
+            step2_future: NoneCoro = structured.call_step(ctx, step2, args=["task2"])
+            assert_ctx_task_step(ctx, "task2", STEP_MAIN_ID)
+            await step1_future
+            assert_ctx_task_step(ctx, "task2", STEP_MAIN_ID)
+            await step2_future
+            assert_ctx_task_step(ctx, "task2", STEP_MAIN_ID)
+
+    @structured.step("step1")
+    async def step1(ctx: structured.WorkflowContext, called_from_task: str) -> None:
+        assert_ctx_task_step(ctx, called_from_task, "step1")
+
+    @structured.step("step2")
+    async def step2(ctx: structured.WorkflowContext, called_from_task: str) -> None:
+        assert_ctx_task_step(ctx, called_from_task, "step2")
+
+    @structured.workflow("workflow")
+    class Workflow:
+        @structured.workflow_entrypoint()
+        async def run(self, ctx: structured.WorkflowContext) -> None:
+            assert_ctx_task_step(ctx, TASK_MAIN_ID, STEP_MAIN_ID)
+            t1_future: NoneCoro = structured.call_task(ctx, Task1.run)
+            t2_future: NoneCoro = structured.call_task(ctx, Task2.run)
+            assert_ctx_task_step(ctx, TASK_MAIN_ID, STEP_MAIN_ID)
+            await t1_future
+            assert_ctx_task_step(ctx, TASK_MAIN_ID, STEP_MAIN_ID)
+            await t2_future
+            assert_ctx_task_step(ctx, TASK_MAIN_ID, STEP_MAIN_ID)

--- a/tests/workflows/test_node_state.py
+++ b/tests/workflows/test_node_state.py
@@ -7,67 +7,67 @@ class TestNodeStates:
         wfrun = Workflow(id="test_workflow").run()
 
         # Default node state should be default __main__/__main__
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         wfrun.goto_step("step_1")
-        assert wfrun.current_node_info.id == "__main__/step_1"
+        assert wfrun.node_info.id == "__main__/step_1"
 
         wfrun.goto_task("task_1")
-        assert wfrun.current_node_info.id == "task_1/__main__"
+        assert wfrun.node_info.id == "task_1/__main__"
 
         wfrun.goto_step("step_1")
-        assert wfrun.current_node_info.id == "task_1/step_1"
+        assert wfrun.node_info.id == "task_1/step_1"
 
     def test_call(self) -> None:
         wfrun = Workflow(id="test_workflow").run()
 
         # Default node state should be default __main__/__main__
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # Call a particular step
         step_handle = wfrun.call_step("step_1")
-        assert wfrun.current_node_info.id == "__main__/step_1"
+        assert wfrun.node_info.id == "__main__/step_1"
 
         step_handle.close(WorkflowStatus.COMPLETED)
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # Call a particular task
         task_handle = wfrun.call_task("task_1")
-        assert wfrun.current_node_info.id == "task_1/__main__"
+        assert wfrun.node_info.id == "task_1/__main__"
 
         task_handle.close(WorkflowStatus.COMPLETED)
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # The code below outlines undefined behavior when call_step is called multiple times before being closed
         # The code below is an example of an anti-pattern that should not be used
         step1_handle = wfrun.call_step("step_1")
-        assert wfrun.current_node_info.id == "__main__/step_1"
+        assert wfrun.node_info.id == "__main__/step_1"
         step2_handle = wfrun.call_step("step_2")
-        assert wfrun.current_node_info.id == "__main__/step_2"
+        assert wfrun.node_info.id == "__main__/step_2"
 
         # This will update the node state to the previous state of the step_1
         step1_handle.close(WorkflowStatus.COMPLETED)
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # After step_2 is closed, the node state will be updated to the previous state of the step_2 which is step_1
         step2_handle.close(WorkflowStatus.COMPLETED)
-        assert wfrun.current_node_info.id == "__main__/step_1"
+        assert wfrun.node_info.id == "__main__/step_1"
 
     def test_spawn(self) -> None:
         wfrun = Workflow(id="test_workflow").run()
 
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # Let's add a step outside a spawn group
         first_spawn = wfrun.spawn_step("step_0")
 
         # Current task id should stay the same
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         with wfrun.spawn_group() as sg:
             sg.spawn_step("step_1")
             # Current node state did not change
-            assert wfrun.current_node_info.id == "__main__/__main__"
+            assert wfrun.node_info.id == "__main__/__main__"
             assert wfrun._node_state.next_states[1].info.id == "__main__/step_1"
             assert (
                 wfrun._node_state.next_states[1].info.status == WorkflowStatus.RUNNING
@@ -76,7 +76,7 @@ class TestNodeStates:
 
             sg.spawn_step("step_2")
             # Current node state did not change
-            assert wfrun.current_node_info.id == "__main__/__main__"
+            assert wfrun.node_info.id == "__main__/__main__"
             assert wfrun._node_state.next_states[2].info.id == "__main__/step_2"
             assert (
                 wfrun._node_state.next_states[2].info.status == WorkflowStatus.RUNNING
@@ -85,7 +85,7 @@ class TestNodeStates:
 
             sg.spawn_task("task_1")
             # Current node state did not change
-            assert wfrun.current_node_info.id == "__main__/__main__"
+            assert wfrun.node_info.id == "__main__/__main__"
             assert wfrun._node_state.next_states[3].info.id == "task_1/__main__"
             assert (
                 wfrun._node_state.next_states[3].info.status == WorkflowStatus.RUNNING
@@ -98,12 +98,12 @@ class TestNodeStates:
         assert states[1].info.status == WorkflowStatus.COMPLETED
         assert states[2].info.status == WorkflowStatus.COMPLETED
         assert states[3].info.status == WorkflowStatus.COMPLETED
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # Now when we close the first spawn should the first spawn's status be updated
         first_spawn.close(WorkflowStatus.COMPLETED)
         assert wfrun._node_state.next_states[0].info.status == WorkflowStatus.COMPLETED
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
     def test_spawn_group_exception(self) -> None:
         wfrun = Workflow(id="test_workflow").run()
@@ -116,7 +116,7 @@ class TestNodeStates:
         except ValueError:
             pass
         # Check that the current node id did not change
-        assert wfrun.current_node_info.id == "__main__/__main__"
+        assert wfrun.node_info.id == "__main__/__main__"
 
         # Check that the spawned nodes are in failed state
         assert wfrun._node_state.next_states[0].info.status == WorkflowStatus.FAILED


### PR DESCRIPTION
When you call a task or a step in a structured workflow, clone the context and then appropriately update the node state when the task or step is spawned, and then when it either succeeds or fails.