### PR TITLE
Fix inconsistencies with "documents" table

### DIFF
--- a/db/migrations/20240624012918_mem-cache-docs-and-forms.sql
+++ b/db/migrations/20240624012918_mem-cache-docs-and-forms.sql
@@ -29,7 +29,10 @@ CREATE TABLE public.documents (
     workflow_run_id text,
     path text NOT NULL,
     metadata jsonb NOT NULL,
-    contents text NOT NULL
+    contents text NOT NULL,
+    task text,
+    step text,
+    versions jsonb
 );
 
 CREATE INDEX idx_documents_path ON public.documents (path);

--- a/src/fixpoint/_storage/definitions.py
+++ b/src/fixpoint/_storage/definitions.py
@@ -1,0 +1,31 @@
+"""Definitions for storage tables"""
+
+__all__ = ["DOCS_SQLITE_TABLE", "DOCS_POSTGRES_TABLE"]
+
+DOCS_SQLITE_TABLE = """
+CREATE TABLE IF NOT EXISTS documents (
+    id text PRIMARY KEY,
+    workflow_id text,
+    workflow_run_id text,
+    path text NOT NULL,
+    metadata jsonb NOT NULL,
+    contents text NOT NULL,
+    task text,
+    step text,
+    versions jsonb
+);
+"""
+
+DOCS_POSTGRES_TABLE = """
+CREATE TABLE if NOT EXISTS public.documents (
+    id text PRIMARY KEY,
+    workflow_id text,
+    workflow_run_id text,
+    path text NOT NULL,
+    metadata jsonb NOT NULL,
+    contents text NOT NULL,
+    task text,
+    step text,
+    versions jsonb
+);
+"""

--- a/src/fixpoint/workflows/imperative/_doc_storage.py
+++ b/src/fixpoint/workflows/imperative/_doc_storage.py
@@ -6,7 +6,7 @@ import json
 import sqlite3
 from typing import Any, Dict, List, Optional, Protocol
 
-from fixpoint._storage import SupportsStorage
+from fixpoint._storage import SupportsStorage, definitions as storage_definitions
 from fixpoint._storage.sql import format_where_clause
 from .document import Document
 
@@ -68,21 +68,7 @@ class OnDiskDocStorage(DocStorage):
     def __init__(self, conn: sqlite3.Connection):
         self._conn = conn
         with self._conn:
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS documents (
-                    id text PRIMARY KEY,
-                    workflow_id text,
-                    workflow_run_id text,
-                    path text NOT NULL,
-                    metadata jsonb NOT NULL,
-                    contents text NOT NULL,
-                    task text,
-                    step text,
-                    versions jsonb
-                );
-                """
-            )
+            self._conn.execute(storage_definitions.DOCS_SQLITE_TABLE)
 
     # pylint: disable=redefined-builtin
     def get(self, id: str) -> Optional[Document]:

--- a/tests/workflows/imperative/test_documents.py
+++ b/tests/workflows/imperative/test_documents.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple
 import pytest
+from fixpoint._storage import definitions as storage_definitions
 from fixpoint.workflows.imperative.workflow import Workflow
 from fixpoint.workflows.imperative.document import Document
 from fixpoint.workflows.imperative.config import create_docs_supabase_storage
@@ -71,16 +72,9 @@ class TestDocuments:
         [
             (
                 f"""
-        CREATE TABLE IF NOT EXISTS public.documents (
-            id text PRIMARY KEY,
-            workflow_id text,
-            workflow_run_id text,
-            path text NOT NULL,
-            metadata jsonb NOT NULL,
-            contents text NOT NULL
-        );
+        {storage_definitions.DOCS_POSTGRES_TABLE}
 
-        TRUNCATE TABLE public.documents
+        TRUNCATE TABLE public.documents;
         """,
                 "public.documents",
             )

--- a/tests/workflows/imperative/test_workflow.py
+++ b/tests/workflows/imperative/test_workflow.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple, TypeVar
 from pydantic import BaseModel, Field
 import pytest
 
+from fixpoint._storage import definitions as storage_definitions
 from fixpoint.workflows import imperative
 from fixpoint.workflows.imperative import Form
 from ...supabase_test_utils import supabase_setup_url_and_key, is_supabase_enabled
@@ -55,17 +56,7 @@ class TestWorkflowRun:
         [
             (
                 f"""
-        CREATE TABLE IF NOT EXISTS public.documents (
-            id text PRIMARY KEY,
-            workflow_id text,
-            workflow_run_id text,
-            path text NOT NULL,
-            metadata jsonb NOT NULL,
-            contents text NOT NULL,
-            task text,
-            step text,
-            versions jsonb
-        );
+        {storage_definitions.DOCS_POSTGRES_TABLE}
 
         TRUNCATE TABLE public.documents;
         """,


### PR DESCRIPTION
For the workflow documents table, we had inconsistent column definitions across these declarations:

1. our migration files in `db/migrations`
2. SQLite instations in `.../imperative/_doc_storage.py`
3. Supabase table creations in `tests/...`

Create a new `src/fixpoint/_storage/definitions.py` file to colocate the "documents" table definition.

Unforunately, we cannot use this Python module in our `db/migrations` files because they are SQL files, but we can use it elsewhere.